### PR TITLE
Add link to the website contribution document

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+src/content/contributing/website/_index.en.md


### PR DESCRIPTION
Make a link from README.md to the website contribution document, in such a way
that if anybody opens the github repository will find the same instructions we are publishing
on the website itself.