### PR TITLE
Create a basic quickstart guide and move the basic deployment details

### DIFF
--- a/src/content/deployment/_index.en.md
+++ b/src/content/deployment/_index.en.md
@@ -5,3 +5,58 @@ weight: 10
 pre: "<b>2. </b>"
 ---
 
+The inner details of deploying a broker and connecting clusters to the broker are complicated, subctl automates and simplifies most of those details eliminating human error as much as possible. This is why **subctl** is the recommended deployment method, you can find a complete guide to the subctl tool here: [subctl in detail](subctl). If you still believe _helm_ works better for you, please go [here](helm).
+
+## Installing subctl
+
+Download the subctl binary and make it available on your PATH.
+
+<!-- TODO: create a "getsubctl.sh" to simplify this -->
+```bash
+mkdir -p ~/.local/bin
+curl -L -o ~/.local/bin/subctl https://github.com/submariner-io/submariner-operator/releases/download/v0.1.0/subctl-v0.1.0-linux-amd64
+chmod a+x ~/.local/bin/subctl
+export PATH=$PATH:~/.local/bin
+echo export PATH=\$PATH:~/.local/bin >> ~/.profile
+```
+
+
+## Deployment of broker
+
+Please remember, this cluster's API should be accessible from all other clusters:
+```bash
+subctl deploy-broker --kubeconfig <PATH-TO-KUBECONFIG-BROKER> 
+```
+
+this will create:
+
+* The submariner-k8s-broker namespace
+* The Cluster and Endpoint (.submariner.io) CRDs in the cluster
+* A service account in the namespace for subsequent subctl access.
+* A random IPSEC PSK which will be stored only on the broker-info.subm file.
+
+And generate a broker-info.subm file which contains the following elements:
+
+* The API endpoint
+* A CA certificate to for the API endpoint
+* The service account token for accessing the API endpoint / submariner-k8s-broker namespace.
+
+
+{{% notice info %}}
+This cluster can also participate on the dataplane connectivity with the other clusters, but it will need to be joined (see following step)
+{{% /notice %}}
+
+## Joining clusters
+
+
+For each cluster you want to join:
+```bash
+subctl join --kubeconfig <PATH-TO-JOINING-CLUSTER> broker-info.subm
+```
+
+subctl will discover as much as it can, and ask you for any necessary detail it can't figure out like the cluster ID which has to be different between all clusters.
+
+
+## Discovery
+
+Service discovery (via DNS and lighthouse project) is an experimental (developer preview), and the instructions to deploy with discovery can be found [here](with-discovery/)

--- a/src/content/deployment/_index.en.md
+++ b/src/content/deployment/_index.en.md
@@ -33,7 +33,7 @@ this will create:
 * The submariner-k8s-broker namespace
 * The Cluster and Endpoint (.submariner.io) CRDs in the cluster
 * A service account in the namespace for subsequent subctl access.
-* A random IPSEC PSK which will be stored only on the broker-info.subm file.
+* A random IPSEC PSK which will be stored only in the `broker-info.subm` file.
 
 And generate a broker-info.subm file which contains the following elements:
 
@@ -43,7 +43,7 @@ And generate a broker-info.subm file which contains the following elements:
 
 
 {{% notice info %}}
-This cluster can also participate on the dataplane connectivity with the other clusters, but it will need to be joined (see following step)
+This cluster can also participate in the dataplane connectivity with the other clusters, but it will need to be joined (see following step)
 {{% /notice %}}
 
 ## Joining clusters
@@ -59,4 +59,4 @@ subctl will discover as much as it can, and ask you for any necessary detail it 
 
 ## Discovery
 
-Service discovery (via DNS and lighthouse project) is an experimental (developer preview), and the instructions to deploy with discovery can be found [here](with-discovery/)
+Service discovery (via DNS and lighthouse project) is an experimental feature (developer preview), and the instructions to deploy with discovery can be found [here](with-discovery/)

--- a/src/content/deployment/with-discovery.md
+++ b/src/content/deployment/with-discovery.md
@@ -15,7 +15,7 @@ The [Lighthouse](https://github.com/submariner-io/lighthouse) project helps in c
 - kubefedctl installed ([0.1.0-rc3](https://github.com/kubernetes-sigs/kubefed/releases/tag/v0.1.0-rc3)).
 - kubectl installed.
 
-### To deploy Submariner with Lighthouse follow the below steps
+### Deploying Submariner with Lighthouse
 
 #### Deploy Broker
 

--- a/src/content/deployment/with-discovery.md
+++ b/src/content/deployment/with-discovery.md
@@ -23,11 +23,11 @@ The [Lighthouse](https://github.com/submariner-io/lighthouse) project helps in c
 subctl deploy-broker --kubeconfig <PATH-TO-KUBECONFIG-BROKER> --service-discovery --broker-cluster-context <BROKER-CONTEXT-NAME>
 ```
 
-kubefed will be installed in the broker cluster, as lighthouse currently depends on it for resource distribution. Such dependency will be eliminated in the future.
+kubefed will be installed in the broker cluster, as lighthouse currently depends on it for resource distribution. This dependency will be eliminated in the future.
 
 #### Join Clusters
 
-To join all the other clusters with the broker cluster run using the broker-info.subm generated in the folder from which the previous step was run.
+To join all the other clusters with the broker cluster, run subctl using the broker-info.subm generated in the folder from which the previous step was run.
 
 {{% notice info %}}
 You will need a kubeconfig file with multiple contexts, a default admin context pointing to
@@ -41,4 +41,3 @@ subctl join --kubeconfig <PATH-TO-KUBECONFIG-DATA-CLUSTER> broker-info.subm  --b
 
 As for a normal deployment, subctl will try to figure out all necessary information and will
 ask for anything it can't figure out.
-

--- a/src/content/deployment/with-discovery.md
+++ b/src/content/deployment/with-discovery.md
@@ -1,0 +1,44 @@
+---
+title: "With Discovery (experimental)"
+date: 2020-02-20T16:40:57+01:00
+---
+
+
+Deployment with discovery will include the ([lighthouse](https://github.com/submariner-io/lighthouse) components.
+
+{{% notice warning %}}
+ **Project status**: The Lighthouse project is meant only to be used as a development preview. Installing the operator on an Openshift cluster may disable some of the operator features.
+{{% /notice %}}
+
+The [Lighthouse](https://github.com/submariner-io/lighthouse) project helps in cross-cluster service discovery. It has the below **additional dependencies**
+
+- kubefedctl installed ([0.1.0-rc3](https://github.com/kubernetes-sigs/kubefed/releases/tag/v0.1.0-rc3)).
+- kubectl installed.
+
+### To deploy Submariner with Lighthouse follow the below steps
+
+#### Deploy Broker
+
+```
+subctl deploy-broker --kubeconfig <PATH-TO-KUBECONFIG-BROKER> --service-discovery --broker-cluster-context <BROKER-CONTEXT-NAME>
+```
+
+kubefed will be installed in the broker cluster, as lighthouse currently depends on it for resource distribution. Such dependency will be eliminated in the future.
+
+#### Join Clusters
+
+To join all the other clusters with the broker cluster run using the broker-info.subm generated in the folder from which the previous step was run.
+
+{{% notice info %}}
+You will need a kubeconfig file with multiple contexts, a default admin context pointing to
+the cluster you're trying to join, and another context which provides access to the broker
+cluster from the previous step. This is a requirement from kubefedctl.
+{{% /notice %}}
+
+```
+subctl join --kubeconfig <PATH-TO-KUBECONFIG-DATA-CLUSTER> broker-info.subm  --broker-cluster-context <BROKER-CONTEXT-NAME>
+```
+
+As for a normal deployment, subctl will try to figure out all necessary information and will
+ask for anything it can't figure out.
+

--- a/src/content/quickstart/_index.en.md
+++ b/src/content/quickstart/_index.en.md
@@ -12,8 +12,8 @@ this topic can be found in the [Architecture](../architecture) section.
 
 #### The broker
 The broker is an API to which all participating clusters are given access and where two objects are exchanged via CRDs:
-* Cluster(.submariner.io): defines a participating cluster and it's IP CIDRs.
-* Endpoint(.submariner.io): defines a connection endpoint to a Cluster, and the reachable cluster IPs from such endpoint.
+* Cluster(.submariner.io): defines a participating cluster and its IP CIDRs.
+* Endpoint(.submariner.io): defines a connection endpoint to a Cluster, and the reachable cluster IPs from the endpoint.
 
 The broker must be deployed on a single Kubernetes cluster. This cluster’s API server must be reachable by all Kubernetes clusters connected by Submariner. It can be a dedicated cluster, or one of the connected clusters.
 
@@ -27,7 +27,7 @@ Submariner has a few requirements to get started:
 
 - At least **2 Kubernetes** clusters, one of which is designated to serve as the central broker that is accessible by all of your connected clusters; this can be one of your connected clusters, but comes with the limitation that the cluster is required to be up to facilitate interconnectivity/negotiation.
 
-- Different service/pod CIDR's between clusters. This is to prevent routing conflicts.
+- Different service/pod CIDRs between clusters. This is to prevent routing conflicts.
 <!-- This is not true yet, but eventually will be: (as well as different Kubernetes DNS suffixes).
 -->
 - Direct **IP connectivity between the gateway nodes** through the internet (or on the same network if not running Submariner over the internet). Submariner supports 1:1 NAT setups but has a few caveats/provider-specific configuration instructions in this configuration.<!--TODO: add section explaining nat -->

--- a/src/content/quickstart/_index.en.md
+++ b/src/content/quickstart/_index.en.md
@@ -1,17 +1,68 @@
 +++
-title = "Quickstart"
+title = "Quickstart guide"
 date = 2020-02-19T20:03:44+01:00
 weight = 5
 pre = "<b>1. </b>"
 +++
 
+## Basic overview
 
-# Quickstart guide
+Submariner has two main core pieces (the broker and submariner), more information about 
+this topic can be found in the [Architecture](../architecture) section.
 
-## Installing
+#### The broker
+It's an API, to which all participating clusters are given access, and where two objects are exchanged via CRDs:
+* Cluster(.submariner.io): defines a participating cluster and it's IP CIDRs.
+* Endpoint(.submariner.io): defines a connection endpoint to a Cluster, and the reachable cluster IPs from such endpoint.
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+This part should be deployed on one K8s cluster, a participating cluster could be the broker as
+long as all other clusters can reach this cluster API.
 
-## Requirements
+#### The submariner deployment on a cluster
+Once submariner is deployed on a cluster with the proper credentials to the broker it will exchange Cluster and Endpoint objects with other clusters (via push/pull/watching), and start forming connections and routes to other clusters.
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+## Prerequisites
+
+Submariner has a few requirements to get started:
+
+- At least **2 Kubernetes** clusters, one of which is designated to serve as the central broker that is accessible by all of your connected clusters; this can be one of your connected clusters, but comes with the limitation that the cluster is required to be up to facilitate interconnectivity/negotiation.
+
+- Different service/pod CIDR's between clusters. This is to prevent routing conflicts.
+<!-- This is not true yet, but eventually will be: (as well as different Kubernetes DNS suffixes).
+-->
+- Direct **IP connectivity between the gateway nodes** through the internet (or on the same network if not running Submariner over the internet). Submariner supports 1:1 NAT setups but has a few caveats/provider-specific configuration instructions in this configuration.<!--TODO: add section explaining nat -->
+
+- Knowledge of each cluster's network configuration.
+
+- Worker node IPs on all the clusters must be outside of the cluster/service CIDR ranges.
+
+An example of three clusters configured to use with Submariner would look like the following:
+
+| Cluster Name | Provider | Pods CIDR    | Service CIDR | Cluster Nodes CIDR |
+|:-------------|:---------|:-------------|:-------------|--------------------|
+| broker       | AWS      | 10.42.0.0/16 | 10.43.0.0/16 | 192.168.1.0/24     |
+| west         | vSphere  | 10.0.0.0/16  | 10.1.0.0/16  | 192.168.1.0/24     |
+| east         | OnPrem   | 10.98.0.0/16 | 10.99.0.0/16 | 192.168.1.0/24     |
+
+
+## Deployment
+
+The available methods for deployment are:
+  * [subctl](../deployment) (+ submariner-operator).
+  * helm charts.
+  
+  
+The community recommends the use of **_subctl_**, because it simplifies most of the
+manual steps required for deployment, as well as verification of connectivity between the clusters. In the _future_ it may provide additional capabilities like:
+
+* Detection of possible conflicts
+* Upgrade management
+* Status inspection of the deployment
+* Configuration updates
+* Maintenance and debugs tasks
+* Wrapping of logs for support tasks.
+
+
+To deploy submariner with **subctl** please follow the [deployment](../deployment) guide.
+If **helm** fits better your deployment methodologies, please find the details [here](../deployment/helm)

--- a/src/content/quickstart/_index.en.md
+++ b/src/content/quickstart/_index.en.md
@@ -11,7 +11,7 @@ Submariner has two main core pieces (the broker and submariner), more informatio
 this topic can be found in the [Architecture](../architecture) section.
 
 #### The broker
-It's an API, to which all participating clusters are given access, and where two objects are exchanged via CRDs:
+The broker is an API to which all participating clusters are given access and where two objects are exchanged via CRDs:
 * Cluster(.submariner.io): defines a participating cluster and it's IP CIDRs.
 * Endpoint(.submariner.io): defines a connection endpoint to a Cluster, and the reachable cluster IPs from such endpoint.
 

--- a/src/content/quickstart/_index.en.md
+++ b/src/content/quickstart/_index.en.md
@@ -15,8 +15,7 @@ The broker is an API to which all participating clusters are given access and wh
 * Cluster(.submariner.io): defines a participating cluster and it's IP CIDRs.
 * Endpoint(.submariner.io): defines a connection endpoint to a Cluster, and the reachable cluster IPs from such endpoint.
 
-This part should be deployed on one K8s cluster, a participating cluster could be the broker as
-long as all other clusters can reach this cluster API.
+The broker must be deployed on a single Kubernetes cluster. This cluster’s API server must be reachable by all Kubernetes clusters connected by Submariner. It can be a dedicated cluster, or one of the connected clusters.
 
 #### The submariner deployment on a cluster
 Once submariner is deployed on a cluster with the proper credentials to the broker it will exchange Cluster and Endpoint objects with other clusters (via push/pull/watching), and start forming connections and routes to other clusters.


### PR DESCRIPTION

Some small details have been modified from the operator readme to make it clearer/easier. 
Once this is merged we can remove those details from the operator guide.