### PR TITLE
Fix .File.UniqueID on zero object warning

### DIFF
--- a/src/themes/hugo-theme-learn/layouts/partials/menu.html
+++ b/src/themes/hugo-theme-learn/layouts/partials/menu.html
@@ -94,12 +94,14 @@
 {{ define "section-tree-nav" }}
 {{ $showvisitedlinks := .showvisitedlinks }}
 {{ $currentNode := .currentnode }}
+{{ $currentFileUniqueID := "" }}
+{{ with $currentNode.File }}{{ $currentFileUniqueID = .UniqueID }}{{ end }}
  {{with .sect}}
   {{if and .IsSection ((not .Params.hidden) or $.showhidden)}}
     {{safeHTML .Params.head}}
     <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item 
         {{if .IsAncestor $currentNode }}parent{{end}}
-        {{if eq .File.UniqueID $currentNode.File.UniqueID}}active{{end}}
+        {{if eq .File.UniqueID $currentFileUniqueID}}active{{end}}
         {{if .Params.alwaysopen}}parent{{end}}
         ">
       <a href="{{.RelPermalink}}">
@@ -137,7 +139,7 @@
     </li>
   {{else}}
     {{ if not .Params.Hidden }}
-      <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item {{if eq .File.UniqueID $currentNode.File.UniqueID}}active{{end}}">
+      <li data-nav-id="{{.RelPermalink}}" title="{{.Title}}" class="dd-item {{if eq .File.UniqueID $currentFileUniqueID}}active{{end}}">
         <a href="{{ .RelPermalink}}">
         {{safeHTML .Params.Pre}}{{or .Params.menuTitle .LinkTitle .Title}}{{safeHTML .Params.Post}}
         {{ if $showvisitedlinks}}<i class="fas fa-check read-icon"></i>{{end}}
@@ -147,4 +149,3 @@
   {{end}}
  {{ end }}
 {{ end }}
-


### PR DESCRIPTION
Avoid warning message when hugo is building the site:

Building sites … WARN 2020/03/10 15:05:30 .File.UniqueID on zero object.
Wrap it in if or with: {{ with .File }}{{ .UniqueID }}{{ end }}

cherry picked from  https://github.com/matcornic/hugo-theme-learn/pull/372/