### PR TITLE
Fix gitignore rules for hugo files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 output/**
-./hugo
+.hugo/
+hugo


### PR DESCRIPTION
Correctly ignore the .hugo/ and ./hugo files generated by make server.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>