### PR TITLE
Adopt CNCF code-of-conduct for Submariner

### DIFF
--- a/src/content/contributing/code-of-conduct/_index.en.md
+++ b/src/content/contributing/code-of-conduct/_index.en.md
@@ -11,4 +11,4 @@ Submariner follows the [CNCF Code of Conduct][1].
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the Submariner Committers.
 
-[1]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md
+[1]: https://github.com/cncf/foundation/blob/bec34a2614c980f8cfe38b18105e0baa820936cc/code-of-conduct.md

--- a/src/content/contributing/code-of-conduct/_index.en.md
+++ b/src/content/contributing/code-of-conduct/_index.en.md
@@ -4,3 +4,11 @@ date: 2020-02-19T21:43:46+01:00
 weight: 20
 ---
 
+## Submariner Community Code of Conduct
+
+Submariner follows the [CNCF Code of Conduct][1].
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the Submariner Committers.
+
+[1]: https://github.com/cncf/foundation/blob/master/code-of-conduct.md


### PR DESCRIPTION
Follow Kubernetes example and adopt the CNCF code-code-conduct, which is
in turn based on the Contributor Covenant.

Closes: #10

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>