### PR TITLE
Don't nest Build/Test docs under empty dev section

### DIFF
--- a/src/content/contributing/building_testing/_index.en.md
+++ b/src/content/contributing/building_testing/_index.en.md
@@ -4,6 +4,9 @@ date: 2020-03-18T16:03:26+01:00
 weight: 10
 ---
 
+Submariner strives to be an open, welcoming community for developers.
+Substantial tooling is provided to ease the contribution experience.
+
 ## Standard Development Environment
 
 Submariner provides a standard, shared development environment suitable for all

--- a/src/content/contributing/developers/_index.en.md
+++ b/src/content/contributing/developers/_index.en.md
@@ -1,8 +1,0 @@
----
-title: "Developers"
-date: 2020-03-18T16:03:26+01:00
-weight: 11
----
-
-Submariner strives to be an open, welcoming community for developers.
-Substantial tooling is provided to ease the contribution experience.


### PR DESCRIPTION
Per feedback, move the Building and Testing docs out of the almost-empty
Developers section and make them a top-level section under Contributing.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>