### PR TITLE
Define the include shortcode and deduplicate AWS openshift install

### DIFF
--- a/src/content/quickstart/openshift/_index.md
+++ b/src/content/quickstart/openshift/_index.md
@@ -5,34 +5,7 @@ title: "OpenShift (AWS)"
 
 ## AWS
 
-### openshift-install and pull-secret
-
-Download the **openshift-install** and _oc_ tools, and copy your _pull secret_ from:
-
-> https://cloud.redhat.com/openshift/install/aws/installer-provisioned
-
-Find more detailed instructions here:
-
-> https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-default.html
-
-
-### Make sure the aws cli is properly installed and configured
-
-Installation instructions
-
-> https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html
-
-```bash
-$ aws configure
-AWS Access Key ID [None]: ....
-AWS Secret Access Key [None]: ....
-Default region name [None]: ....
-Default output format [None]: text
-```
-
-See also for more details:
-
-> https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-account.html
+{{< include "quickstart/openshift/setup_openshift.md" >}}
 
 ### Create and deploy cluster A
 

--- a/src/content/quickstart/openshift/setup_openshift.md
+++ b/src/content/quickstart/openshift/setup_openshift.md
@@ -1,0 +1,28 @@
+### openshift-install and pull-secret
+
+Download the **openshift-install** and _oc_ tools, and copy your _pull secret_ from:
+
+> https://cloud.redhat.com/openshift/install/aws/installer-provisioned
+
+Find more detailed instructions here:
+
+> https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-default.html
+
+
+### Make sure the aws cli is properly installed and configured
+
+Installation instructions
+
+> https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html
+
+```bash
+$ aws configure
+AWS Access Key ID [None]: ....
+AWS Secret Access Key [None]: ....
+Default region name [None]: ....
+Default output format [None]: text
+```
+
+See also for more details:
+
+> https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-account.html

--- a/src/content/quickstart/openshiftgn/_index.md
+++ b/src/content/quickstart/openshiftgn/_index.md
@@ -6,34 +6,7 @@ weight: 15
 
 ## AWS
 
-### openshift-install and pull-secret
-
-Download the **openshift-install** and _oc_ tools, and copy your _pull secret_ from:
-
-> https://cloud.redhat.com/openshift/install/aws/installer-provisioned
-
-Find more detailed instructions here:
-
-> https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-default.html
-
-
-### Make sure the aws cli is properly installed and configured
-
-Installation instructions
-
-> https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html
-
-```bash
-$ aws configure
-AWS Access Key ID [None]: ....
-AWS Secret Access Key [None]: ....
-Default region name [None]: ....
-Default output format [None]: text
-```
-
-See also for more details:
-
-> https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-account.html
+{{< include "quickstart/openshift/setup_openshift.md" >}}
 
 ### Create cluster A
 

--- a/src/content/quickstart/openshiftsd/_index.md
+++ b/src/content/quickstart/openshiftsd/_index.md
@@ -6,34 +6,7 @@ weight: 15
 
 ## AWS
 
-### openshift-install and pull-secret
-
-Download the **openshift-install** and _oc_ tools, and copy your _pull secret_ from:
-
-> https://cloud.redhat.com/openshift/install/aws/installer-provisioned
-
-Find more detailed instructions here:
-
-> https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-default.html
-
-
-### Make sure the aws cli is properly installed and configured
-
-Installation instructions
-
-> https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html
-
-```bash
-$ aws configure
-AWS Access Key ID [None]: ....
-AWS Secret Access Key [None]: ....
-Default region name [None]: ....
-Default output format [None]: text
-```
-
-See also for more details:
-
-> https://docs.openshift.com/container-platform/4.3/installing/installing_aws/installing-aws-account.html
+{{< include "quickstart/openshift/setup_openshift.md" >}}
 
 ### Create and deploy cluster A
 

--- a/src/layouts/shortcodes/include.html
+++ b/src/layouts/shortcodes/include.html
@@ -1,0 +1,6 @@
+{{ $file := .Get 0 }}
+{{ if strings.HasSuffix $file ".html" }}
+{{  $file  | readFile  | safeHTML }}
+{{ else if strings.HasSuffix $file ".md" }}
+{{  $file  | readFile  | markdownify  }}
+{{ end }}


### PR DESCRIPTION
Introduces the include short code, and we use it to deduplicate
the content across openshift-install and pull secrets, etc...
between all the openshift guides.