### PR TITLE
Fix links broken by language option removal

### DIFF
--- a/src/content/contributing/community-membership/_index.en.md
+++ b/src/content/contributing/community-membership/_index.en.md
@@ -183,7 +183,7 @@ The following apply to people who would be an owner:
 [parent process]: https://github.com/kubernetes/community/blob/7d2ebad43cde06607cde3d55e9eed4bb08a286a9/community-membership.md
 [code reviews]: https://github.com/kubernetes/community/blob/7d2ebad43cde06607cde3d55e9eed4bb08a286a9/contributors/guide/collab.md
 [community expectations]: https://github.com/kubernetes/community/blob/7d2ebad43cde06607cde3d55e9eed4bb08a286a9/contributors/guide/expectations.md
-[contributor guide]: https://submariner-io.github.io/en/contributing/
+[contributor guide]: https://submariner-io.github.io/contributing/
 [Submariner org]: https://github.com/submariner
 [submariner-dev@googlegroups.com]: https://groups.google.com/forum/#!forum/submariner-dev
 [open issue]: https://github.com/submariner-io/submariner/issues/new

--- a/src/content/contributing/release-process/_index.en.md
+++ b/src/content/contributing/release-process/_index.en.md
@@ -194,7 +194,7 @@ If this is a pre-release, mark the checkbox "This is a pre-release".
 
 # Verify the version
 
-You can follow any of our quickstarts, for example [this](https://submariner-io.github.io/en/quickstart/openshiftgn/)
+You can follow any of our quickstarts, for example [this](https://submariner-io.github.io/quickstart/openshiftgn/)
 
 # Announce
 


### PR DESCRIPTION
When we removed Spanish language support, the English-explicit links
broke. Remove the 'en' part of URLs to fix.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>