### PR TITLE
Add reporting contacts to Code of Contact

### DIFF
--- a/src/content/contributing/code-of-conduct/_index.en.md
+++ b/src/content/contributing/code-of-conduct/_index.en.md
@@ -6,9 +6,12 @@ weight: 20
 
 ## Submariner Community Code of Conduct
 
-Submariner follows the [CNCF Code of Conduct][1].
+Submariner follows the [CNCF Code of Conduct][cncf coc].
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the Submariner Committers.
+reported by contacting one or more of the Submariner [Committers][committers]
+or [Owners][owners].
 
-[1]: https://github.com/cncf/foundation/blob/bec34a2614c980f8cfe38b18105e0baa820936cc/code-of-conduct.md
+[cncf coc]: https://github.com/cncf/foundation/blob/bec34a2614c980f8cfe38b18105e0baa820936cc/code-of-conduct.md
+[committers]: https://submariner-io.github.io/contributing/community-membership/#committers
+[owners]: https://github.com/orgs/submariner-io/teams/submariner-core/members


### PR DESCRIPTION
Link to details of actual people (committers/owners) who should be
contacted in the event of Code of Conduct violations.

Closes: #64

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>