### PR TITLE
Add initial docs style guide

### DIFF
--- a/src/content/contributing/website/style_guide.md
+++ b/src/content/contributing/website/style_guide.md
@@ -1,0 +1,29 @@
+---
+title: "Docs Style Guide"
+date: 2020-04-29T19:09:55+02:00
+weight: 5
+---
+
+## Documentation Style Guide
+
+This guide is meant to help keep our documentation consistent and ease the
+contribution and review process.
+
+Submariner follows the [Kubernetes Documentation Style Guide][kube docs guide]
+wherever relevant. This is a Submariner-specific extension of those practices.
+
+### Submariner.io word list
+
+A list of Submariner-specific terms and words to be used consistently across
+the site.
+
+Term | Usage
+:--- | :----
+Submariner | The project name *Submariner* should always be capitalized.
+Admiral | The project name *Admiral* should always be capitalized.
+Lighthouse | The project name *Lighthouse* should always be capitalized.
+Coastguard | The project name *Coastguard* should always be capitalized.
+Shipyard | The project name *Shipyard* should always be capitalized.
+`subctl` | The artifact `subctl` should not be capitalized and should be formatted in code style.
+
+[kube docs guide]: https://kubernetes.io/docs/contribute/style/style-guide


### PR DESCRIPTION
Start a documentation style guide so the community can agree on and
follow best practices as they contribute docs, especially during the
upcoming docs-only sprint.

Follow the upstream K8s Docs Style Guide as a base.

This guide should be extended as contribution/review shows gaps.

Closes: #100

Co-authored-by: Thomas Pantelis <tompantelis@gmail.com>
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>