### PR TITLE
Add Slack link to website left navigation bar

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -32,29 +32,34 @@ url = "https://github.com/submariner-io/"
 weight = 10
 
 [[Languages.en.menu.shortcuts]]
+name = "<i class='fas fa-fw fa-slack'></i> Slack"
+identifier = "slack"
+url = "https://kubernetes.slack.com/archives/C010RJV694M"
+weight = 20
+
+[[Languages.en.menu.shortcuts]]
 name = "<i class='fas fa-fw fa-envelope'></i> User mailing list"
 url = "https://bit.ly/submariner-users"
-weight = 20
+weight = 30
 
 [[Languages.en.menu.shortcuts]]
 name = "<i class='fas fa-fw fa-envelope'></i> Devel mailing list"
 url = "https://bit.ly/submariner-dev"
-weight = 30
+weight = 40
 
 [[Languages.en.menu.shortcuts]]
 name = "<i class='fas fa-fw fa-video'></i> YouTube"
 url = "https://www.youtube.com/channel/UCZ3brSgl2v4boglZoeChClQ/videos"
-weight = 40
-
-[[Languages.en.menu.shortcuts]]
-name = "<i class='fas fa-fw fa-calendar'></i> Google Calendar"
-identifier = "gcal"
-url = "https://calendar.google.com/calendar?cid=NHFuZGVoOGY0bzZ1ajlvZnBsczh1NWNlZ2tAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ"
-weight = 60
+weight = 50
 
 [[Languages.en.menu.shortcuts]]
 name = "<i class='fab fa-fw fa-twitter'></i> Twitter"
 identifier = "twitter"
 url = "https://twitter.com/submarinerio"
-weight = 50
+weight = 60
 
+[[Languages.en.menu.shortcuts]]
+name = "<i class='fas fa-fw fa-calendar'></i> Google Calendar"
+identifier = "gcal"
+url = "https://calendar.google.com/calendar?cid=NHFuZGVoOGY0bzZ1ajlvZnBsczh1NWNlZ2tAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ"
+weight = 70


### PR DESCRIPTION
Link to the Submariner channel on the Kubernetes Slack workspace from
the section with similar links in the website's left bar.

Also slightly reorder links to reflect link weights.

Closes: #111

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>