### PR TITLE
Make logo clickable and point to homepage

### DIFF
--- a/src/layouts/partials/logo.html
+++ b/src/layouts/partials/logo.html
@@ -1,1 +1,5 @@
-<img src="/images/logo-submariner.svg" alt="Submariner"/>
+<a href="/" style="display: block;">
+    <object data="/images/logo-submariner.svg" type="image/svg+xml" style="pointer-events: none;">
+        <span>Your browser doesn't support SVG images</span>
+    </object>
+</a>


### PR DESCRIPTION
Clicking on the Submariner logo (main left side menu) should now point to the homepage. Was tested locally with both Chrome and Firefox.

Closes: https://github.com/submariner-io/submariner-website/issues/97

Signed-off-by: Nir Yechiel <n.yechiel@gmail.com>