### PR TITLE
Use capitalized first letter in titles

### DIFF
--- a/src/content/quickstart/_index.en.md
+++ b/src/content/quickstart/_index.en.md
@@ -1,5 +1,5 @@
 +++
-title = "Quickstart guide"
+title = "Quickstart Guide"
 date = 2020-02-19T20:03:44+01:00
 weight = 5
 pre = "<b>1. </b>"

--- a/src/content/reading_material/_index.en.md
+++ b/src/content/reading_material/_index.en.md
@@ -1,5 +1,5 @@
 ---
-title: "Online resources"
+title: "Online Resources"
 date: 2020-03-09T20:03:44+01:00
 weight: 20
 pre: "<b>5. </b>"


### PR DESCRIPTION
For consistency, changing all titles to use capitalized first letter of every word.

Signed-off-by: Nir Yechiel <n.yechiel@gmail.com>