### PR TITLE
Create detailed subctl guide.

### DIFF
--- a/src/content/deployment/_index.en.md
+++ b/src/content/deployment/_index.en.md
@@ -29,7 +29,7 @@ And generate a broker-info.subm file which contains the following elements:
 * The API endpoint
 * A CA certificate to for the API endpoint
 * The service account token for accessing the API endpoint / submariner-k8s-broker namespace.
-* A random IPSEC PSK which will be stored only in this file.
+* A random IPsec PSK which will be stored only in this file.
 * Globalnet settings
 * Service discovery settings
 

--- a/src/content/deployment/_index.en.md
+++ b/src/content/deployment/_index.en.md
@@ -23,13 +23,15 @@ this will create:
 * The submariner-k8s-broker namespace
 * The Cluster and Endpoint (.submariner.io) CRDs in the cluster
 * A service account in the namespace for subsequent subctl access.
-* A random IPSEC PSK which will be stored only in the `broker-info.subm` file.
 
 And generate a broker-info.subm file which contains the following elements:
 
 * The API endpoint
 * A CA certificate to for the API endpoint
 * The service account token for accessing the API endpoint / submariner-k8s-broker namespace.
+* A random IPSEC PSK which will be stored only in this file.
+* Globalnet settings
+* Service discovery settings
 
 
 {{% notice info %}}

--- a/src/content/deployment/subctl.en.md
+++ b/src/content/deployment/subctl.en.md
@@ -62,12 +62,11 @@ broker-info file.
 | Flag                               | Description
 |:-----------------------------------|:----------------------------------------------------------------------------|
 | `--cable-driver` `<string>`        | Cable driver implementation (defaults to strongswan -IPSec-)
-| `--clusterid` `<string>`           | Cluster ID used to identify the tunnels. Every cluster needs to have an unique cluster ID, if not provided `subctl` will prompt the admin for a cluster ID.
-| `--clustercidr` `<string>`         | Cluster CIDR specify a cluster CIDR (generally the IP addresses used for the pods in this cluster), if not specified subctl will try to discover this detail, and if it's unable to discover it will prompt the admin.
-| `--colorcodes` `<string>`          | Color codes (default "blue"), coma separated values. Please use with caution, as it may change in the future. This setting is used to make Submariner gateway form connections only with clusters which share the same color code. This will be replaced by something more flexible in the future.
-| `--no-label `                      | Skip gateway labeling this will disable prompting the administrator for a worker node to use as gateway.
+| `--clusterid` `<string>`           | Cluster ID used to identify the tunnels. Every cluster needs to have a unique cluster ID, if not provided `subctl` will prompt the admin for a cluster ID.
+| `--clustercidr` `<string>`         | Specifies the cluster's CIDR used to generate Pod IP addresses. If not specified, subctl will try to discover it and, if unable to do so, it will prompt the user.
+| `--no-label `                      | Skip gateway labeling. This disables the prompt for a worker node to use as gateway.
 | `--subm-debug`                     | Enable Submariner debugging (verbose logging)
-| `--disable-cvo`                    | Disable OpenShift's cluster version operator if necessary, without prompting. Currently, lighthouse service modifies the cluster dns operator in OpenShift and we need to disable CVO, this setting disables the prompt which warns the administrator.
+| `--disable-cvo`                    | Disable OpenShift's cluster version operator, if necessary, without prompting as a warning. Currently, Lighthouse modifies the cluster DNS operator in OpenShift to disable CVO.
 
 #### join flags (globalnet)
 
@@ -89,11 +88,11 @@ broker-info file.
 
 | Flag                                    | Description
 |:----------------------------------------|:----------------------------------------------------------------------------|
-| `--repository` `<string>`               | Image repository, the repository from where the various submariner images will be sourced. (default "quay.io/submariner")
+| `--repository` `<string>`               | The repository from where the various submariner images will be sourced. (default "quay.io/submariner")
 | `--version` `<string>`                  | Image version
-| `-o`, `--operator-image` `<string>`     | The operator image you wish to use (default "quay.io/submariner/submariner-operator:$version")
-| `--service-discovery-repo` `<string>`   | Service Discovery Image repository (default "quay.io/submariner")
-| `--service-discovery-version` `<string>`| Service Discovery Image version
+| `-o`, `--operator-image` `<string>`     | The operator image location (default "quay.io/submariner/submariner-operator:$version")
+| `--service-discovery-repo` `<string>`   | Service Discovery image repository (default "quay.io/submariner")
+| `--service-discovery-version` `<string>`| Service Discovery image version
 
 ### info
 

--- a/src/content/deployment/subctl.en.md
+++ b/src/content/deployment/subctl.en.md
@@ -12,7 +12,7 @@ Submariner across your clusters.
 
 ## Description
 
-`subctl` helps to automate the deployment of the Submariner [operator](https://github.com/submariner-io/submariner-operator) thereby reducing the possibility of mistakes during the process.
+`subctl` helps to automate the deployment of the Submariner [operator](https://github.com/submariner-io/submariner-operator), thereby reducing the possibility of mistakes during the process.
 
 `subctl` connects to specified cluster(s) and performs the requested *command*.
 
@@ -117,7 +117,11 @@ The `verify-connectivity` command verifies dataplane connectivity between two cl
 `kubeConfig1` file will be `ClusterA` in the reports, while `kubeConfig2` will be `ClusterB` in the
 reports. The `--verbose` flag is recommended to see what's happening during the tests.
 
-Dataplane connectivity is verified in multiple ways: between pods and services, between pods and pods,
+Dataplane connectivity is verified in multiple ways:
+ * Pods (on gateways) to Services
+ * Pods (on non-gateways) to Services
+ * Pods (on gateways) to Pods
+ * Pods (on non-gateways) to Pods
 and between gateway and non-gateway node combinations.
 
 

--- a/src/content/deployment/subctl.en.md
+++ b/src/content/deployment/subctl.en.md
@@ -1,0 +1,143 @@
+---
+title: "subctl"
+weight: 10
+---
+
+`subctl` is a command line utility designed to simplify the deployment and maintenance of
+Submariner across your clusters.
+
+## Synopsis
+
+`subctl [command] [--flags] ...`
+
+## Description
+
+`subctl` helps to automate the deployment of the Submariner [operator](https://github.com/submariner-io/submariner-operator) thereby reducing the possibility of mistakes during the process.
+
+`subctl` connects to specified cluster(s) and performs the requested *command*.
+
+## Commands
+
+### deploy-broker
+
+`subctl deploy-broker [flags]`
+
+The **deploy-broker** command configures the cluster specified by the `--kubeconfig` flag
+(or `KUBECONFIG` env var) and the `--kubecontext` flag as the Broker. It installs
+the necessary CRDs and the `submariner-k8s-broker` namespace.
+
+In addition, it generates a `broker-info.subm` file which can be used with the `join` command
+to connect clusters to the Broker. This file contains the following details:
+
+ * Encryption PSK key
+ * Broker access details for subsequent `subctl` runs.
+ * Service discovery settings
+ * Globalnet settings
+
+#### deploy-broker flags
+
+
+| Flag                               | Description
+|:-----------------------------------|:----------------------------------------------------------------------------|
+|`--kubeconfig` `<string>`           | Absolute path(s) to the kubeconfig file(s) (default "$HOME/.kube/config")
+|`--kubecontext` `<string>`          | kubeconfig context to use
+|`--service-discovery`               | Enable Multi Cluster Service Discovery
+|`--globalnet`                       | Enable support for Overlapping cluster/service CIDRs in connecting clusters (default disabled)
+|`--globalnet-cidr-range` `<string>` | Global CIDR supernet range for allocating GlobalCIDRs to each cluster (default "169.254.0.0/16")
+|`--ipsec-psk-from` `<string>`       | Import IPSEC PSK from existing Submariner broker file, like broker-info.subm (default "broker-info.subm)
+|`--dataplane`                       | Install the Submariner dataplane on the broker. If this flag is enabled, the broker will be joined as if a join command was run right after deploy-broker. Use the join flags too if you use --dataplane.
+
+### join
+
+`subctl join broker-info.subm [flags]`
+
+The **join** command deploys the Submariner operator in a cluster using the settings provided in the `broker-info.subm` file.
+The service account credentials needed for the new cluster to access the Broker cluster will be created and provided to the Submariner operator
+deployment. All the other settings like service discovery enablement and globalnet support are sourced from the
+broker-info file.
+
+
+#### join flags (general)
+
+| Flag                               | Description
+|:-----------------------------------|:----------------------------------------------------------------------------|
+| `--cable-driver` `<string>`        | Cable driver implementation (defaults to strongswan -IPSec-)
+| `--clusterid` `<string>`           | Cluster ID used to identify the tunnels. Every cluster needs to have an unique cluster ID, if not provided `subctl` will prompt the admin for a cluster ID.
+| `--clustercidr` `<string>`         | Cluster CIDR specify a cluster CIDR (generally the IP addresses used for the pods in this cluster), if not specified subctl will try to discover this detail, and if it's unable to discover it will prompt the admin.
+| `--colorcodes` `<string>`          | Color codes (default "blue"), coma separated values. Please use with caution, as it may change in the future. This setting is used to make Submariner gateway form connections only with clusters which share the same color code. This will be replaced by something more flexible in the future.
+| `--no-label `                      | Skip gateway labeling this will disable prompting the administrator for a worker node to use as gateway.
+| `--subm-debug`                     | Enable Submariner debugging (verbose logging)
+| `--disable-cvo`                    | Disable OpenShift's cluster version operator if necessary, without prompting. Currently, lighthouse service modifies the cluster dns operator in OpenShift and we need to disable CVO, this setting disables the prompt which warns the administrator.
+
+#### join flags (globalnet)
+
+| Flag                                 | Description
+|:-------------------------------------|:----------------------------------------------------------------------------|
+| `--globalnet-cluster-size` `<value>` | Cluster size for GlobalCIDR allocated to this cluster (amount of global IPs).
+| `--globalnet-cidr` `<string>`        | GlobalCIDR to be allocated to the cluster, this setting is exclusive with `--globalnet-cluster-size` and configures a specific globalnet CIDR for this cluster.
+
+#### join flags (IPSec)
+
+| Flag                    | Description
+|:------------------------|:-----------------------------------------------|
+| `--disable-nat`         | Disable NAT for IPsec.
+| `--ikeport` `<value>`   | IPsec IKE port (default 500)
+| `--ipsec-debug`         | Enable IPsec debugging (verbose logging)
+| `--nattport` `<value>`  | IPsec NATT port (default 4500)
+
+#### join flags (images and repositories)
+
+| Flag                                    | Description
+|:----------------------------------------|:----------------------------------------------------------------------------|
+| `--repository` `<string>`               | Image repository, the repository from where the various submariner images will be sourced. (default "quay.io/submariner")
+| `--version` `<string>`                  | Image version
+| `-o`, `--operator-image` `<string>`     | The operator image you wish to use (default "quay.io/submariner/submariner-operator:$version")
+| `--service-discovery-repo` `<string>`   | Service Discovery Image repository (default "quay.io/submariner")
+| `--service-discovery-version` `<string>`| Service Discovery Image version
+
+### info
+
+`subctl info [flags]`
+
+The `info` command inspects the cluster and reports information related to Submariner, like the
+detected network plugin, and the detected Cluster and Service CIDRs.
+
+#### info flags
+
+| Flag                         | Description
+|:-----------------------------|:----------------------------------------------------------------------------|
+| `--kubeconfig` `<string>`    | Absolute path(s) to the kubeconfig file(s) (default "$HOME/.kube/config")
+| `--kubecontext` `<string>`   | Kubeconfig context to use
+
+### verify-connectivity
+
+`subctl verify-connectivity <kubeConfig1> <kubeConfig2> [flags]`
+
+The `verify-connectivity` command verifies dataplane connectivity between two clusters. The
+`kubeConfig1` file will be `ClusterA` in the reports, while `kubeConfig2` will be `ClusterB` in the
+reports. The `--verbose` flag is recommended to see what's happening during the tests.
+
+Dataplane connectivity is verified in multiple ways: between pods and services, between pods and pods,
+and between gateway and non-gateway node combinations.
+
+
+#### verify-connectivity flags
+
+| Flag                                | Description
+|:------------------------------------|:----------------------------------------------------------------------------|
+| `--connection-attempts` `<value>`   | The maximum number of connection attempts (default 2)
+| `--connection-timeout` `<value>`    | The timeout in seconds per connection attempt  (default 60)
+| `--operation-timeout` `<value>`     | Operation timeout for K8s API calls (default 240)
+| `--report-dir` `<string>`           | XML report directory (default ".")
+| `--verbose`                         | Produce verbose logs during connectivity verification
+
+### version
+
+`subctl version`
+
+Prints the version details for the subctl binary.
+
+
+## Installation
+
+{{< subctl-install >}}

--- a/src/content/deployment/subctl/_index.en.md
+++ b/src/content/deployment/subctl/_index.en.md
@@ -1,6 +1,0 @@
----
-title: "Using Subctl"
-date: 2020-02-19T21:25:35+01:00
-weight: 10
----
-

--- a/src/themes/hugo-theme-learn/static/css/theme.css
+++ b/src/themes/hugo-theme-learn/static/css/theme.css
@@ -631,8 +631,8 @@ code {
     border-radius: 2px;
     white-space: nowrap;
     color: #5e5e5e;
-    background: #FFF7DD;
-    border: 1px solid #fbf0cb;
+    background: #f2f2f2;
+    border: 1px solid #eeeeee;
     padding: 0px 2px;
 }
 code + .copy-to-clipboard {

--- a/src/themes/hugo-theme-learn/static/js/learn.js
+++ b/src/themes/hugo-theme-learn/static/js/learn.js
@@ -179,7 +179,7 @@ jQuery(document).ready(function() {
         var code = $(this),
             text = code.text();
 
-        if (text.length > 5) {
+        if (text.length > 30) { // We have a minimum limit to avoid the copy-to-clipboard on `small` `tags`
             if (!clipInit) {
                 var text, clip = new ClipboardJS('.copy-to-clipboard', {
                     text: function(trigger) {


### PR DESCRIPTION
 This commit also fixes the behaviour and looks of small code snippets
like `subctl ...` etc. Where the javascript was adding a clipboard icon
and using yellow. This removes the clipboard icon and uses gray.

The reason for the style/js changes are to move from this:
![Screenshot from 2020-05-07 13-42-18](https://user-images.githubusercontent.com/1176434/81290631-b1128180-9068-11ea-8937-e5e1799b7346.png)

to this:

![Screenshot from 2020-05-07 13-44-05](https://user-images.githubusercontent.com/1176434/81290718-da331200-9068-11ea-965a-ccfadc9f92c4.png)
