### PR TITLE
Rancher quickstart guide

### DIFF
--- a/src/content/quickstart/rancher/_index.md
+++ b/src/content/quickstart/rancher/_index.md
@@ -1,0 +1,43 @@
+---
+date: 2020-05-15T15:30:00+00:00
+title: "Rancher 2.x"
+weight: 10
+---
+
+{{< include "quickstart/rancher/prerequisites.md" >}}
+{{< include "quickstart/rancher/create_clusters.md" >}}
+
+### Install subctl
+
+{{< subctl-install >}}
+
+Obtain the kubeconfig files from the Rancher UI for each of your clusters, placing them in the respective kubeconfigs.
+
+|Cluster|Kubeconfig File Name|
+|----|---|
+|Cluster A|kubeconfig-cluster-a|
+|Cluster B|kubeconfig-cluster-b|
+
+### Use cluster-a as broker
+
+```bash
+subctl deploy-broker --kubeconfig kubeconfig-cluster-a
+```
+
+### Join cluster-a and cluster-b to the broker
+
+```bash
+subctl join --kubeconfig kubeconfig-cluster-a broker-info.subm --clusterid cluster-a
+```
+
+```bash
+subctl join --kubeconfig kubeconfig-cluster-b broker-info.subm --clusterid cluster-b
+```
+
+### Verify connectivity
+
+This will run a series of E2E tests to verify proper connectivity between the cluster pods and services
+
+```bash
+subctl verify-connectivity kubeconfig-cluster-a kubeconfig-cluster-b --verbose
+```

--- a/src/content/quickstart/rancher/create_clusters.md
+++ b/src/content/quickstart/rancher/create_clusters.md
@@ -1,0 +1,37 @@
+### Create and Deploy Cluster A
+
+In this step you will deploy cluster A, with the default IP CIDRs
+
+| Pod CIDR     | Service CIDR |
+|--------------|--------------|
+|10.42.0.0/16  |10.43.0.0/16  |
+
+Use the Rancher UI to create a cluster, leaving the default options selected.
+
+Make sure you create at least one node that has a publicly accessible IP with the label `submariner.io/gateway: "true"`, either via node pool or via a custom node registration command.
+
+### Create and Deploy Cluster B
+
+In this step you will deploy cluster B, modifying the default IP CIDRs
+
+| Pod CIDR     | Service CIDR |
+|--------------|--------------|
+|10.44.0.0/16  |10.45.0.0/16  |
+
+Create your cluster, but select `Edit as YAML` in the cluster creation UI. Edit the services stanza to reflect the options below, while making sure to keep the options that were already defined.
+
+```bash
+  services:
+    kube-api:
+      service_cluster_ip_range: 10.45.0.0/16
+    kube-controller:
+      cluster_cidr: 10.44.0.0/16
+      service_cluster_ip_range: 10.45.0.0/16
+    kubelet:
+      cluster_domain: cluster.local
+      cluster_dns_server: 10.45.0.10
+```
+
+Make sure you create at least one node that has a publicly accessible IP with the label `submariner.io/gateway: "true"`, either via node pool or via a custom node registration command.
+
+Once you have done this, you can deploy your cluster.

--- a/src/content/quickstart/rancher/prerequisites.md
+++ b/src/content/quickstart/rancher/prerequisites.md
@@ -1,0 +1,5 @@
+## Prerequisites
+
+These instructions were developed with Rancher v2.4.x
+
+Make sure you are familiar with Rancher, and creating clusters. You can create either node driver clusters or Custom clusters, as long as your designated gateway nodes can communicate with each other.


### PR DESCRIPTION
This is a very basic Rancher 2.4.x quickstart guide, primarily detailed around how to create a custom cluster with custom CIDR's.