### PR TITLE
Update Lighthouse Release process page

### DIFF
--- a/src/content/contributing/release-process/_index.en.md
+++ b/src/content/contributing/release-process/_index.en.md
@@ -42,7 +42,7 @@ Verify that the build successfully completes as indicated by a green checkmark a
 
 To create lighthouse release artifacts follow the steps below.
 
-### Build Lighthouse Controller
+### Build Lighthouse Agent and CoreDNS
 
 Assuming that you have an existing lighthouse git directory, run the following steps .
 
@@ -68,72 +68,9 @@ For this example the build can be found [here](https://travis-ci.com/github/subm
 
 Verify that the build successfully completes as indicated by a green checkmark at the right. At this point the images tagged with 0.2.0-rc0 will be available on quay.io at:
 
-> https://quay.io/repository/submariner/lighthouse-controller?tab=tags
+> https://quay.io/repository/submariner/lighthouse-agent?tab=tags
 > https://quay.io/repository/submariner/lighthouse-coredns?tab=tags
 
-### Build Lighthouse CoreDNS
-
-1) Get the coredns repository and change to the folder
-
-```bash
-go get github.com/openshift/coredns
-cd $GOPATH/src/github.com/openshift/coredns
-```
-2) Build the image and push
-
-```bash
-COREDNS_VERSION=<VERSION-NO>
-LH_COREDNS_VERSION=<LH-VERSION-NO>
-COREDNS_IMAGE="lighthouse-coredns:${LH_COREDNS_VERSION}"
-git checkout -b ${COREDNS_VERSION}
-sed -i '/^kubernetes:kubernetes/a lighthouse:github.com/submariner-io/lighthouse/plugin/lighthouse' plugin.cfg
-sed -i '/^github.com/aws/aws-sdk-go/a github.com/submariner-io/lighthouse v0.2.0' go.mod
-sed -i '$a replace\ k8s.io\/apimachinery\ =>\ k8s.io\/apimachinery\ v0.0.0-20190313205120-d7deff9243b1' go.mod
-sed -i '$a replace\ github.com\/openzipkin-contrib\/zipkin-go-opentracing\ =>\ github.com\/openzipkin-contrib\/zipkin-go-opentracing\ v0.3.5' go.mod
-docker build  -f Dockerfile.openshift -t quay.io/submariner/${COREDNS_IMAGE} .
-docker push quay.io/submariner/${COREDNS_IMAGE}
-```
-
-### Build Cluster-DNS-Operator
-
-1) Clone the cluster-dns-operator repository and create a version branch
-
-```bash
-git clone https://github.com/submariner-io/cluster-dns-operator.git
-git checkout -b <VERSION-NO>
-```
-
-2) Change the coredns and cluster dns operator versions.
-
-```
-	- name: dns-operator
-          terminationMessagePolicy: FallbackToLogsOnError
-          image: quay.io/submariner/lighthouse-cluster-dns-operator:<VERSION-NO>
-          command:
-          - dns-operator
-          env:
-          - name: RELEASE_VERSION
-            value: "0.0.1-snapshot"
-          - name: IMAGE
-            value: quay.io/submariner/lighthouse-coredns:<VERSION-NO>
-```
-
-For example,
-https://github.com/submariner-io/cluster-dns-operator/pull/1/files#diff-8c85a5683e17f9599cbfc641cceaa040R33
-
-3) Build a new image and upload it to quay.
-
-```bash
-REPO=quay.io/submariner/lighthouse-cluster-dns-operator:$VERSION make release-local
-```
-
-3) Commit and push the changes and raise a PR.
-
-```bash
-git add .
-git commit -s
-git push HEAD:<VERSION-NO>
-```
 
 ## Step 3: Update the Operator Version References and Create a Release
 


### PR DESCRIPTION
The cluster-dns-operator section and the openshift coreDNS section
is removed.

Fixes: submariner-io/submariner-website#152

Signed-off-by: Aswin Surayanarayanan <asuryana@redhat.com>