### PR TITLE
Update subctl.en.md to remove --operator-image

### DIFF
--- a/src/content/deployment/subctl.en.md
+++ b/src/content/deployment/subctl.en.md
@@ -88,7 +88,6 @@ broker-info file.
 |:----------------------------------------|:----------------------------------------------------------------------------|
 | `--repository` `<string>`               | The repository from where the various submariner images will be sourced. (default "quay.io/submariner")
 | `--version` `<string>`                  | Image version
-| `-o`, `--operator-image` `<string>`     | The operator image location (default "quay.io/submariner/submariner-operator:$version")
 
 ### info
 


### PR DESCRIPTION
This flag does not exists anymore since we calculate from
repository and version.

Signed-off-by: Miguel Angel Ajo Pelayo <majopela@redhat.com>