### PR TITLE
Update the release guide

### DIFF
--- a/src/content/contributing/release-process/_index.en.md
+++ b/src/content/contributing/release-process/_index.en.md
@@ -8,131 +8,124 @@ This section explains the necessary steps to make a submariner release.
 It is assumed that you are familiar with the submariner project and the various repositories.
 
 
-## Step 1: Create a Submariner Release
+## Project dependencies
+
+When releasing the submariner components it's important to keep in mind the dependencies between projects, in terms of go libraries and docker images.
+
+**something very important to note is that while in git we use the vx.x.x format, in docker we use x.x.x**
+
+### go dependencies
+`shipyard -e2e framework-` <- `admiral` <- `[submariner, lighthouse]` <- `submariner-operator`
+
+### docker images
+`subctl binary` <- `shipyard` <- `[admiral, submariner, lighthouse, submariner-operator]`
+
+### docker image version notes
+
+Currently, subctl and the operator expect that lighthouse and submariner are aligned on the same exact semver version.
+
+## Step 0: Bump subctl into shipyard image, optional
+
+This is only necessary if you have specific chages which will require a newer subctl version.
+
+Edit ` package/Dockerfile.shipyard-dapper-base` and bump `SUBCTL_VERSION` to the new version, then send a pull request. 
+
+Make sure it's merged.
+
+## Step 1: Release shipyard
+
+Tag and push the shipyard repository (or use the github release interface).
+
+For this example we will use `v0.5.0` as the image.
+
+Once this is done, CI will generate a `quay.io/submariner/shipyard-dapper-base:0.5.0` docker image. 
+
+This step should generate images here:
+
+> https://quay.io/repository/submariner/shipyard-dapper-base?tab=tags
 
 
-Assuming that you have an existing submariner git directory, the following steps create a release named "Globalnet Overlapping IP support RC0" with version v0.2.0-rc0 based on the master branch.
+## Step 2: Admiral
 
-```bash
-cd submariner
-git stash
-git remote add upstream ssh://git@github.com/submariner-io/submariner
-git fetch -a -v -t upstream
-git checkout remotes/upstream/master -B master
-git tag -s -m "Globalnet Overlapping IP support RC0" v0.2.0-rc0
-git push upstream v0.2.0-rc0
+1) Edit `Dockerfile.dapper` and pin the image of shipyard to `0.5.0` instead of `devel`
+
+2) Update the go.mod references:
+```
+make shell
+go get github.com/submariner-io/shipyard@v0.5.0
+go mod vendor
+go mod tidy
+exit
 ```
 
-A tagged release should appear [here](https://github.com/submariner-io/submariner/tags).
+3) Send a pull request with the changes, and make sure it's merged before continuing
 
-> https://github.com/submariner-io/submariner/tags
-
-A build for v0.2.0-rc0 should start and appear under the "Active branches" section [here](https://travis-ci.com/github/submariner-io/submariner/branches).
-
-> https://travis-ci.com/github/submariner-io/submariner/branches
-
-Verify that the build successfully completes as indicated by a green checkmark at the right. At this point the images tagged with 0.2.0-rc0 will be available [here](https://quay.io/repository/submariner/submariner?tab=tags).
-
-> https://quay.io/repository/submariner/submariner?tab=tags
-
-<!-- TODO(mangelajo) https://github.com/submariner-io/submariner-website/issues/46 -->
+4) tag/push the merged changes as `v0.5.0`, or use the github interface to release admiral.
 
 
-## Step 2: Create a Lighthouse Release
+## Step 3: Submariner & Lighthouse
 
-To create lighthouse release artifacts follow the steps below.
+go to `submariner` and `lighthouse`,
 
-### Build Lighthouse Agent and CoreDNS
+1) Edit `Dockerfile.dapper` and pin the image of shipyard to `0.5.0`
 
-Assuming that you have an existing lighthouse git directory, run the following steps .
-
-```bash
-cd lighthouse
-git stash
-git remote add upstream ssh://git@github.com/submariner-io/lighthouse
-git fetch -a -v -t upstream
-git checkout remotes/upstream/master -B master
-git tag -s -m "Globalnet Overlapping IP support RC0" v0.2.0-rc0
-git push upstream v0.2.0-rc0
+2) Update the `go.mod` references
 ```
+make shell
+go get github.com/submariner-io/shipyard@v0.5.0
+go get github.com/submariner-io/admiral@v0.5.0
+go mod vendor
+go mod tidy
+```
+3) Send a pull request with the changes, and make sure it's merged before continuing
 
-A tagged release should appear [here](https://github.com/submariner-io/lighthouse/tags)
+4) tag/push the merged changes as `v0.5.0`, or use the github interface to release submariner/lighthouse.
 
-> https://github.com/submariner-io/lighthouse/tags
-
-A build for v0.2.0-rc0 should start and appear under the "Active branches" section [here](https://travis-ci.com/github/submariner-io/lighthouse/branches)
-
-> https://travis-ci.com/github/submariner-io/lighthouse/branches
-
-For this example the build can be found [here](https://travis-ci.com/github/submariner-io/lighthouse/builds/153946391).
-
-Verify that the build successfully completes as indicated by a green checkmark at the right. At this point the images tagged with 0.2.0-rc0 will be available on quay.io at:
+This step should generate images here:
 
 > https://quay.io/repository/submariner/lighthouse-agent?tab=tags
 > https://quay.io/repository/submariner/lighthouse-coredns?tab=tags
 
+## Step 4: Operator / subctl
 
-## Step 3: Update the Operator Version References and Create a Release
+go to `submariner-operator`
 
-Once the other builds have finished and you have 0.2.0-rc0 release tags for the submariner and lighthouse projects, you can proceed with changes to the operator.
+1) Edit `Dockerfile.dapper` and pin the image of shipyard to `0.5.0`
 
-### Change Referenced Versions
-
-Edit the operator [versions](https://github.com/submariner-io/submariner-operator/edit/master/pkg/versions/versions.go) file and change the project version constants to reference the new release, "0.2.0-rc0".
-
-
-```bash
-cd submariner-operator
-git stash
-git remote add upstream ssh://git@github.com/submariner-io/submariner-operator
-git fetch -a -v -t upstream
-git checkout remotes/upstream/master -B update-references-to-v0.2.0-rc0
-vim pkg/versions/versions.go
-# make sure we are referencing the latest submariner code (we use it for verify-connectivity and the API)
-GO111MODULES=on go get github.com/submariner-io/submariner@v0.2.0-rc0
-git push my-repo update-references-to-v0.2.0-rc0
+2) Update the `go.mod` references
+```
+make shell
+go get github.com/submariner-io/shipyard@v0.5.0
+go get github.com/submariner-io/admiral@v0.5.0
+go get github.com/submariner-io/submariner@v0.5.0
+go get github.com/submariner-io/lighthouse@v0.5.0
+go mod vendor
+go mod tidy
 ```
 
+3) Edit versions/versions.go to update the referenced versions to `v0.5.0`
 
-Create a pull request, wait for the CI job to pass, and get approval/merge. See an example PR [here](https://github.com/submariner-io/submariner-operator/pull/276)
+3) Send a pull request with the changes, and make sure it's merged before continuing
 
+4) tag/push the merged changes as `v0.5.0`, or use the github interface to release submariner-operator and subctl.
 
-### Create a Submariner-Operator Release
-
-Assuming you have an existing submariner-operator git directory, run the following steps:
-
-```bash
-cd submariner-operator
-git stash
-git remote add upstream ssh://git@github.com/submariner-io/submariner-operator
-git fetch -a -v -t upstream
-git checkout remotes/upstream/master -B master
-git tag -s -m "Globalnet Overlapping IP support RC0" v0.2.0-rc0
-git push upstream v0.2.0-rc0
-```
-
-A tagged release should appear [here](https://github.com/submariner-io/submariner-operator/tags).
-
-> https://github.com/submariner-io/submariner-operator/tags
-
-A build for v0.2.0-rc0 should start and appear under the under the "Active branches" section [here](https://travis-ci.com/github/submariner-io/submariner-operator/branches).
-
-> https://travis-ci.com/github/submariner-io/submariner-operator/branches
-
-Verify that the build successfully completes as indicated by a green checkmark at the right.
-At this point the images tagged with 0.2.0-rc0 will be available [here](https://quay.io/repository/submariner/submariner-operator?tab=tags).
+This step should generate images here:
 
 > https://quay.io/repository/submariner/submariner-operator?tab=tags
+
+And binaries here (see the Assets section):
+
+> https://github.com/submariner-io/submariner-operator/releases
 
 
 ### Verify the Subctl Binaries Release
 
 At this point, you should see subctl binaries generated and listed for the various platforms under the release
- https://github.com/submariner-io/submariner-operator/tags, find the tag for v0.2.0-rc0 , verify that the binaries uploaded, the process needs around 5 minutes.
+ https://github.com/submariner-io/submariner-operator/tags, find the tag for 0.5.0 , verify that the binaries uploaded, the process needs around 5 minutes.
  
  ### Update the release notes
  
- Go to https://github.com/submariner-io/submariner-operator/tags, find the tag for v0.2.0-rc0 and select "Edit release" to the right. 
+ Go to https://github.com/submariner-io/submariner-operator/tags, find the tag for `v0.5.0` and select "Edit release" to the right. 
  
 Update the release notes.
  


### PR DESCRIPTION
It's simplified to assume git knowledge, and go in more
detail about the cross-project dependencies we have now.