### PR TITLE
Remove demo videos from main page

### DIFF
--- a/src/content/_index.en.md
+++ b/src/content/_index.en.md
@@ -33,22 +33,6 @@ Submariner is completely open source, and designed to be network plugin (CNI) ag
 
 </style>
 
-## Demos
-<div class="mygrid">
-  <div>
-    <div> {{< youtube fMhZRNn0fxQ >}}</div>
-    <h5> Connecting Pods and Services across Clusters</h5>
-  </div>
-  <div>
-    <div> {{< youtube cInmBXuZsU8 >}}</div>
-    <h5> Deploying Submariner with subctl</h5>
-  </div>
-  <div>
-    <div> {{< youtube tXsemQPNhyQ >}}</div>
-    <h5> Cross-cluster Service Discovery</h5>
-  </div>
-</div>
-
 {{% notice tip %}}
 Check the [Quickstart guide](./quickstart/) section for deployment instructions.
 {{% /notice %}}


### PR DESCRIPTION
Per discussion on the upstream call, the demo video thumbnail images
contain Red Hat logos, which in this design are overly-prominently
featured on the homepage. In order to reduce obvious branding, remove
the embedded videos from the homepage. They are still linked in the
Online Resources section.

Closes: #206

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>