### PR TITLE
Rename "supercluster" to "clusterset"

### DIFF
--- a/src/content/architecture/service-discovery/_index.en.md
+++ b/src/content/architecture/service-discovery/_index.en.md
@@ -34,8 +34,8 @@ it creates a copy of it in the local cluster.
 
 ### Lighthouse DNS Server
 
-The Lighthouse DNS server runs as an external DNS server which owns the domain supercluster.local.
-KubeDNS is configured to forward any request sent to supercluster.local to the Lighthouse DNS server,
+The Lighthouse DNS server runs as an external DNS server which owns the domain clusterset.local.
+KubeDNS is configured to forward any request sent to clusterset.local to the Lighthouse DNS server,
 which uses the ServiceImport resources that are distributed by the controller for DNS resolution. The
 Lighthouse DNS server uses a round robin algorithm for IP selection to distribute the load evenly across the clusters.
 
@@ -43,7 +43,7 @@ Lighthouse DNS server uses a round robin algorithm for IP selection to distribut
 
 The workflow is as follows.
 
-- A Pod tries to resolve a Service name using the domain name supercluster.local
+- A Pod tries to resolve a Service name using the domain name clusterset.local
 - KubeDNS forwards the request to the Lighthouse DNS server.
 - The Lighthouse DNS server will use its ServiceImport cache to try to resolve the request.
 - If a record exists it will be returned, else an NXDomain error will be returned.

--- a/src/content/deployment/subctl/_index.en.md
+++ b/src/content/deployment/subctl/_index.en.md
@@ -175,7 +175,7 @@ The `connectivity` suite verifies dataplane connectivity across the clusters for
 
 and between gateway and non-gateway node combinations.
 
-The `service-discovery` suite verifies dns discovery of `<service>.<namespace>.svc.supercluster.local` entries across the clusters.
+The `service-discovery` suite verifies dns discovery of `<service>.<namespace>.svc.clusterset.local` entries across the clusters.
 
 The `gateway-failover` suite verifies the continuity of cross-cluster dataplane connectivity after a gateway failure in a cluster occurs.
 This suite requires a single gateway configured on `ClusterA` and other available worker nodes capable of serving as gateways. Please note

--- a/src/content/quickstart/verify_with_discovery.md
+++ b/src/content/quickstart/verify_with_discovery.md
@@ -13,7 +13,7 @@ subctl export service --namespace default nginx
 ```bash
 export KUBECONFIG=cluster-a/auth/kubeconfig
 kubectl -n default  run --generator=run-pod/v1 tmp-shell --rm -i --tty --image quay.io/submariner/nettest -- /bin/bash
-curl nginx.default.svc.supercluster.local:8080
+curl nginx.default.svc.clusterset.local:8080
 ```
 
 #### Perform automated verification

--- a/src/content/releases/_index.en.md
+++ b/src/content/releases/_index.en.md
@@ -39,7 +39,7 @@ weight = 25
 * **Lighthouse** has been modified per the [Kubernetes Multicluster Services KEP][MCS KEP] as follows:
   * A `ServiceExport` object needs to be created alongside any `Service` that is intended to be
     exported to participant clusters.
-  * Supercluster services can be accessed with `<service-name>.<namespace>.svc.supercluster.local`.
+  * Supercluster services can be accessed with `<service-name>.<namespace>.svc.clusterset.local`.
 * **Globalnet** overlapping CIDR support improvements and bug fixes.
 * Multiple **CI** improvements implemented from Shipyard.
 * CI tests are now run via **[GitHub Actions](https://github.com/submariner-io/submariner/actions)**.

--- a/src/content/troubleshooting/_index.en.md
+++ b/src/content/troubleshooting/_index.en.md
@@ -121,7 +121,7 @@ If there's no error, then check if the Lighthouse CoreDNS server is configured c
 submariner-lighthouse-coredns` and make sure it has following configuration:
 
 ```text
-    supercluster.local:53 {
+    clusterset.local:53 {
         lighthouse
         errors
         health
@@ -131,10 +131,10 @@ submariner-lighthouse-coredns` and make sure it has following configuration:
 
 ##### Check CoreDNS Configuration
 
-Submariner requires the CoreDNS deployment to forward requests for the domain `supercluster.local` to the Lighthouse CoreDNS server in the
+Submariner requires the CoreDNS deployment to forward requests for the domain `clusterset.local` to the Lighthouse CoreDNS server in the
 cluster making the query. Ensure this configuration exists and is correct.
 
-First we check if CoreDNS is configured to forward requests for domain `supercluster.local` to Lighthouse CoreDNS Server in the cluster
+First we check if CoreDNS is configured to forward requests for domain `clusterset.local` to Lighthouse CoreDNS Server in the cluster
 making the query.
 
 `kubectl describe configmap coredns`
@@ -142,7 +142,7 @@ making the query.
 In the output look for something like this:
 
 ```text
-    supercluster.local:53 {
+    clusterset.local:53 {
         forward . <lighthouse-coredns-serviceip> ======> ServiceIP of lighthouse-coredns service as noted in previous section
     }
 ```
@@ -208,7 +208,7 @@ Spec:
   Ports:                    <nil>
   Session Affinity:
   Session Affinity Config:  <nil>
-  Type:                     SuperclusterIP
+  Type:                     ClusterSetIP
 Status:
   Clusters:
     Cluster:  cluster2 ==========> ClusterID of cluster where service is running


### PR DESCRIPTION
The latter is the name chosen by the multi-cluster SIG.

Signed-off-by: Stephen Kitt <skitt@redhat.com>