### PR TITLE
Ensure CNAME File is generated by CI

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -15,6 +15,8 @@ rm -rf $OUTPUT/*
 # copy new content
 cp -rf output/* $OUTPUT
 
+echo "submariner.io" > ${OUTPUT}/CNAME
+
 cd $OUTPUT
 git add **
 git commit -a -m "Updated website from submariner-io/website ${COMMIT_ID}"


### PR DESCRIPTION
The CI currently clobbers the CNAME file created on the `submariner-io.github.io` repository, so we should make sure that we are adding/managing it with our source of truth.