### PR TITLE
Use HTML to increase font size vs header levels

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -5,3 +5,6 @@ header-start-left: false
 single-trailing-newline: false
 header-increment: false
 ul-start-left: false
+no-inline-html:
+  allowed_elements:
+    - span

--- a/src/content/_index.en.md
+++ b/src/content/_index.en.md
@@ -1,6 +1,6 @@
 # Submariner
 
-#### Submariner enables direct networking between Pods and Services in different Kubernetes clusters, either on premise or in the cloud.
+<span style="font-size:1.5em;">Submariner enables direct networking between Pods and Services in different Kubernetes clusters, either on premise or in the cloud.</span>
 
 ## Why Submariner?
 


### PR DESCRIPTION
Use inline HTML to set the font size of the main Submariner mission
statement to 50% above the browser default, vs abusing subheadings to
get larger fonts.

Allow HTML span tags in markdownlint.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>