### PR TITLE
Enable header-start-left and ul-start-left MD lint

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,7 +1,10 @@
-line-length: false
+# Breaks reusing MD snippets extracted to files
 first-line-heading: false
-header-start-left: false
-ul-start-left: false
+
+# Allow HTML span elements to set font sizes
 no-inline-html:
   allowed_elements:
     - span
+
+# FIXME: Enable these, fix errors
+line-length: false


### PR DESCRIPTION
Both rules had all their violations corrected by other PRs fixing other
issues. Enable them so future errors can't slip in.

Also note that first-line-heading MD linting isn't a goal, since it
breaks our model of reusing MD snippets extracted to files.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>