### PR TITLE
Fix subctl export service args in quickstart docs

### DIFF
--- a/src/content/quickstart/kind/_index.md
+++ b/src/content/quickstart/kind/_index.md
@@ -61,7 +61,7 @@ To manually verify the deployment follow the steps below.
 ```bash
 kubectl --kubeconfig output/kubeconfigs/kind-config-cluster3 create deployment nginx --image=nginx
 kubectl --kubeconfig output/kubeconfigs/kind-config-cluster3 expose deployment nginx --port=80
-subctl export service --namespace default nginx
+subctl export service --kubeconfig output/kubeconfigs/kind-config-cluster3 --namespace default nginx
 ```
 
 #### Perform automated verification


### PR DESCRIPTION
Before fix:
```
$ subctl export service --namespace default nginx
Unable to find the Service "nginx" in namespace "default": Get "http://localhost:8080/api/v1/namespaces/default/services/nginx": dial tcp [::1]:8080: connect: connection refused

subctl version: v0.5.0
```

After fix:
```
$ subctl export service --kubeconfig output/kubeconfigs/kind-config-cluster3 --namespace default nginx
Service exported successfully
```