### PR TITLE
Update the --subm-debug to --enabled-pod-debugging

### DIFF
--- a/src/content/deployment/subctl/_index.en.md
+++ b/src/content/deployment/subctl/_index.en.md
@@ -81,7 +81,7 @@ deployment. All the other settings like service discovery enablement and globaln
 | `--clustercidr` `<string>`         | Specifies the cluster's CIDR used to generate Pod IP addresses. If not specified, subctl will try to discover it and, if unable to do so, it will prompt the user.
 <!-- markdownlint-enable line-length -->
 | `--no-label`                       | Skip gateway labeling. This disables the prompt for a worker node to use as gateway.
-| `--subm-debug`                     | Enable Submariner debugging (verbose logging)
+| `--enable-pod-debugging`          | Enable Submariner pod debugging (verbose logging in the deployed pods)
 
 #### join flags (globalnet)
 


### PR DESCRIPTION
Subctl change related to submariner-io#545 updates --subm-debug to
--enabled-pod-debugging for clarity. This updates the related documentation.

Related-Issue: submariner-io#545

Signed-off-by: Miguel Angel Ajo Pelayo <majopela@redhat.com>