### PR TITLE
Correct "on-premise" to "on-premises"

### DIFF
--- a/src/content/_index.en.md
+++ b/src/content/_index.en.md
@@ -1,7 +1,7 @@
 # Submariner
 
-<span style="font-size:1.5em;">Submariner enables direct networking between Pods and Services in different Kubernetes clusters, either on
-premise or in the cloud.</span>
+<span style="font-size:1.5em;">Submariner enables direct networking between Pods and Services in different Kubernetes clusters, either
+on-premises or in the cloud.</span>
 
 ## Why Submariner
 

--- a/src/content/architecture/_index.en.md
+++ b/src/content/architecture/_index.en.md
@@ -10,7 +10,7 @@ The diagram below illustrates the basic architecture of Submariner:
 ![Submariner Architecture](/images/submariner/architecture.jpg)
 
 Submariner consists of several main components that work in conjunction to securely connect workloads across multiple Kubernetes clusters,
-both on-premise and on public clouds.
+both on-premises and on public clouds.
 
 * [Gateway Engine](./gateway-engine/): manages the secure tunnels to other clusters.
 * [Route Agent](./route-agent/): routes cross-cluster traffic from nodes to the active Gateway Engine.

--- a/src/content/architecture/broker/_index.en.md
+++ b/src/content/architecture/broker/_index.en.md
@@ -16,7 +16,7 @@ such as its IP, needed for clusters to connect to one another. The `Cluster` CRD
 static information about the originating cluster, such as its Service and Pod CIDRs.
 
 The Broker is a singleton component that is deployed on a cluster whose Kubernetes API must
-be accessible by all of the participating clusters. If there is a mix of on-premise and
+be accessible by all of the participating clusters. If there is a mix of on-premises and
 public clusters, the Broker can be deployed on a public cluster. The Broker cluster may be
 one of the participating clusters or a standalone cluster without the other Submariner
 components deployed. The Gateway Engine components deployed in each participating cluster are

--- a/src/content/quickstart/vsphere_aws/_index.md
+++ b/src/content/quickstart/vsphere_aws/_index.md
@@ -98,7 +98,7 @@ openshift-install create cluster --dir cluster-b
 ### Make your AWS cluster ready for Submariner
 
 Submariner gateway nodes need to be able to accept IPsec traffic. The default ports are 4500/UDP and 500/UDP.
-However, when you have some on-premise clusters (like vSphere in this example) which are typically inside a corporate network, the firewall
+However, when you have some on-premises clusters (like vSphere in this example) which are typically inside a corporate network, the firewall
 configuration on the corporate router may not allow the default IPsec traffic.
 We can overcome this limitation by using non-standard ports like 4501/UDP and 501/UDP.
 


### PR DESCRIPTION
It turns out this is a grammar mistake. Premise is related to logic and
statements only, premises is the location-related term we wanted.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>