### PR TITLE
Document installation options

### DIFF
--- a/src/content/deployment/subctl/_index.en.md
+++ b/src/content/deployment/subctl/_index.en.md
@@ -19,6 +19,24 @@ reducing the possibility of mistakes during the process.
 
 {{< subctl-install >}}
 
+### Installing specific versions
+
+By default, [https://get.submariner.io](https://get.submariner.io) will provide the latest release for `subctl`, and hence Submariner.
+Specific versions can be requested by using the VERSION environment variable.
+
+Avalailable options are:
+
+* `latest`: the latest stable release (default)
+* `devel`: the master branch code.
+* `rc`: the latest release candidate.
+* `x.x.x` (like 0.6.1, 0.5.0, etc)
+
+For example
+
+```bash
+curl https://get.submariner.io | VERSION=devel bash
+```
+
 ## Commands
 
 ### deploy-broker


### PR DESCRIPTION
We provide a VERSION parameter for get.submariner.io which wasn't
documented. This commit adds that information.

Signed-off-by: Miguel Angel Ajo Pelayo <majopela@redhat.com>