### PR TITLE
Capitalize Operator design pattern

### DIFF
--- a/src/content/contributing/release-process/_index.en.md
+++ b/src/content/contributing/release-process/_index.en.md
@@ -216,7 +216,7 @@ Alternatively you can edit the file and create a pull request directly on GitHub
 
 You can follow any of the [quick start guides](../../quickstart).
 
-### Step 9: Update the Submariner operator on OperatorHub.io
+### Step 9: Update the Submariner Operator on OperatorHub.io
 
 The [community-operators](https://github.com/operator-framework/community-operators) Git repository
 is the source for sharing Kubernetes Operators with the broader community. This repository is split into two sections:
@@ -225,7 +225,7 @@ is the source for sharing Kubernetes Operators with the broader community. This 
 These are shared with the Kubernetes community via [OperatorHub.io](https://operatorhub.io/).
 * Operators for deployment to OpenShift (community-operators)
 
-To publish the Submariner operator to the community, perform the following steps:
+To publish the Submariner Operator to the community, perform the following steps:
 
 1) Clone the [submariner-operator](https://github.com/submariner-io/submariner-operator) project
 2) Make sure you have the operator-sdk v0-18-x installed on your machine
@@ -245,16 +245,16 @@ To publish the Submariner operator to the community, perform the following steps
 
    the generated package output should be located in `deploy/olm-catalog/submariner`
 4) Fork and clone [community-operators](https://github.com/operator-framework/community-operators) project.
-5) Update the Kubernetes operator:
+5) Update the Kubernetes Operator:
     * copy the generated package from step 3 into `upstream-community-operators/submariner`
     * compare the new CSV file with the previous one and update the missing fields (e.g spec.description)
     * update the version in `upstream-community-operators/submariner/submariner.package.yaml`
-    * test the operator by running the command: `make operator.test OP_PATH=upstream-community-operators/submariner`
-    * preview the operator on [OperatorHub.io](https://operatorhub.io/preview)
+    * test the Operator by running the command: `make operator.test OP_PATH=upstream-community-operators/submariner`
+    * preview the Operator on [OperatorHub.io](https://operatorhub.io/preview)
     * once everything is fine, review this
     [checklist](https://github.com/operator-framework/community-operators/blob/master/docs/pull_request_template.md)
     and create a new PR on [community-operators](https://github.com/operator-framework/community-operators)
-6) Update the OpenShift operator:
+6) Update the OpenShift Operator:
    * re-run step 5 on the `community-operators/submariner` directory.
 
 ### Step 10: Announce the release

--- a/src/content/contributing/website/style_guide.md
+++ b/src/content/contributing/website/style_guide.md
@@ -25,6 +25,7 @@ Cluster set | The words "cluster set" should be used as a term for a group of cl
 Coastguard | The project name *Coastguard* should always be capitalized.
 Globalnet | The feature name *Globalnet* is one word, and so should always be capitalized and should have a lowercase "n".
 Lighthouse | The project name *Lighthouse* should always be capitalized.
+Operator | The design pattern *Operator* should always be capitalized.
 Shipyard | The project name *Shipyard* should always be capitalized.
 `subctl` | The artifact `subctl` should not be capitalized and should be formatted in code style.
 Submariner | The project name *Submariner* should always be capitalized.

--- a/src/content/deployment/subctl/_index.en.md
+++ b/src/content/deployment/subctl/_index.en.md
@@ -6,7 +6,7 @@ weight: 10
 `subctl` is a command line utility designed to simplify the deployment and maintenance of
 Submariner across your clusters.
 
-`subctl` helps to automate the deployment of the Submariner [operator](https://github.com/submariner-io/submariner-operator), thereby
+`subctl` helps to automate the deployment of the Submariner [Operator](https://github.com/submariner-io/submariner-operator), thereby
 reducing the possibility of mistakes during the process.
 
 `subctl` connects to specified cluster(s) and performs the requested *command*.
@@ -69,8 +69,8 @@ If no `namespace` flag is specified, it uses the default namespace from the curr
 
 `subctl join broker-info.subm [flags]`
 
-The **join** command deploys the Submariner operator in a cluster using the settings provided in the `broker-info.subm` file. The service
-account credentials needed for the new cluster to access the Broker cluster will be created and provided to the Submariner operator
+The **join** command deploys the Submariner Operator in a cluster using the settings provided in the `broker-info.subm` file. The service
+account credentials needed for the new cluster to access the Broker cluster will be created and provided to the Submariner Operator
 deployment.
 
 #### join flags (general)

--- a/src/content/monitoring/_index.en.md
+++ b/src/content/monitoring/_index.en.md
@@ -29,13 +29,13 @@ This currently requires enabling user workload monitoring; see
 [the OpenShift documentation](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/monitoring/monitoring-your-own-services)
 for details.
 
-### Prometheus operator
+### Prometheus Operator
 
-To start monitoring Submariner using the Prometheus operator, Prometheus needs to be configured to scrape the Submariner operator’s
+To start monitoring Submariner using the Prometheus Operator, Prometheus needs to be configured to scrape the Submariner Operator’s
 namespace (`submariner-operator` by default). The specifics depend on your Prometheus deployment, but typically, this will require
 you to:
 
-* add the Submariner operator’s namespace to Prometheus’ `ClusterRoleBinding`;
+* add the Submariner Operator’s namespace to Prometheus’ `ClusterRoleBinding`;
 
 * ensure that Prometheus’ configuration doesn’t prevent it from scraping this namespace.
 

--- a/src/content/reading_material/_index.en.md
+++ b/src/content/reading_material/_index.en.md
@@ -31,7 +31,7 @@ There are multiple presentations/demo recordings on Submariner available online.
 ## SIG Presentations
 
 1. [SIG Multicluster demo of Submariner's KEP1645 Multicluster Services implementation (2020/09/22)](https://youtu.be/bx4z9sMX8FM?t=1350)
-2. [SIG Multicluster demo of Submariner's multicluster networking deployed by Submariner's operator and `subctl` (2019/12/17)](https://youtu.be/4C4kc9AOz4M?t=273)
+2. [SIG Multicluster demo of Submariner's multicluster networking deployed by Submariner's Operator and `subctl` (2019/12/17)](https://youtu.be/4C4kc9AOz4M?t=273)
 
 If you find additional material that isn't listed here, please feel free to add it to this page by editing it.
 The website contributing guide is [here](../contributing/website).

--- a/src/content/releases/_index.en.md
+++ b/src/content/releases/_index.en.md
@@ -25,7 +25,7 @@ weight = 30
   * Enable Service discovery by default for **subctl** deployments.
 * **subctl** auto-detects the cluster ID from the kubeconfig file information when possible.
 * The Submariner Pods now shutdown gracefully and do proper cleanup which reduces the downtime during Gateway failover.
-* The operator now automatically exports Prometheus metrics; these integrate seamlessly with OpenShift Prometheus if user
+* The Operator now automatically exports Prometheus metrics; these integrate seamlessly with OpenShift Prometheus if user
   workload monitoring is enabled, and can be included in any other Prometheus setup.
 * Minimum Kubernetes version is now 1.17.
 * HostNetwork to remote Service connectivity fixes for AWS clusters ([Issue 736](https://github.com/submariner-io/submariner/issues/736)).
@@ -40,7 +40,7 @@ weight = 30
   * The `MultiClusterService` resource has been replaced by `ServiceImport`.
   * The `ServiceExport` resource is now updated with status information as lifecycle events occur.
 * **Lighthouse** now allows a `ServiceExport` resource to be created prior to the associated `Service`.
-* Network discovery was moved from `subctl` to the Submariner operator.
+* Network discovery was moved from `subctl` to the Submariner Operator.
 * Several new commands were added to `subctl`: `export service`, `show versions`, `show connections`, `show networks`,
   `show endpoints`, and `show gateways`.
 * The `subctl info` command has been removed in lieu of the new `show networks` command.
@@ -51,7 +51,7 @@ weight = 30
   cluster to work around this issue. The `globalnet-cidr` will automatically be allocated by `subctl` for each cluster.
 * The separate `--operator-image` parameter has been removed from `subctl join` and the `--repository` and `--version`
   parameters are now used for all images.
-* The Submariner operator status now includes `Gateway` information.
+* The Submariner Operator status now includes `Gateway` information.
 * Closed technical requirements for Submariner to become a CNFC project, including _Developer Certificate of Origin_ compliance,
   and source code linting.
 
@@ -126,7 +126,7 @@ weight = 30
 * Support for updated strongswan (#288)
 * Better iptables detection for some hosts (#227)
 
-> subctl and the submariner operator have the following improvements
+> subctl and the submariner Operator have the following improvements
 
 * support to verify-connectivity between two connected clusters
 * deployment of submariner gateways based in daemonsets instead of deployments
@@ -138,7 +138,7 @@ weight = 30
 
 ## v0.0.3 -- KubeCon NA 2019
 
-Submariner has been greatly enhanced to allow operators to deploy into Kubernetes clusters without the necessity for layer-2 adjacency for
+Submariner has been greatly enhanced to allow Operators to deploy into Kubernetes clusters without the necessity for layer-2 adjacency for
 nodes. Submariner now allows for VXLAN interconnectivity between nodes (facilitated by the route agent). Subctl was created to make
 deployment of submariner easier.
 


### PR DESCRIPTION
Software design patterns, like Operator, seem to be proper nouns and
therefore should be capitalized.

For example, see the classic design pattern book:

Design Patterns: Elements of Reusable Object-Oriented Software
https://www.amazon.com/dp/0201633612

Also fix all instances in a second commit.