### PR TITLE
Clarify "iptables" capitalization

### DIFF
--- a/src/content/architecture/globalnet/_index.en.md
+++ b/src/content/architecture/globalnet/_index.en.md
@@ -29,7 +29,7 @@ the cluster, the supplied globalnet-cidr will be ignored.
 
 Once configured, each Service and Pod that requires cross-cluster access is allocated an IP, named `globalIp`, from this `GlobalCIDR` that
 is annotated on the Pod/Service object. This globalIp is used for all cross-cluster communication to and from a Pod and the globalIp of a
-remote Service. Routing and IPTable rules are configured to use the globalIp for ingress and egress. All address translations occur on the
+remote Service. Routing and iptable rules are configured to use the globalIp for ingress and egress. All address translations occur on the
 Gateway node.
 
 ![Figure 1 - Proposed solution](/images/globalnet/overlappingcidr-solution.png)
@@ -61,13 +61,13 @@ The IP Address Manager (IPAM) component does the following:
 
 #### Globalnet
 
-This component is responsible for programming the routing entries, IPTable rules and does the following:
+This component is responsible for programming the routing entries, iptable rules and does the following:
 
-* Creates initial IPTables chains for Globalnet rules.
+* Creates initial iptables chains for Globalnet rules.
 * Whenever a Pod is annotated with a globalIp, creates an egress SNAT rule to convert the source Ip from the Pod's Ip to the Pod's globalIp
   on the Gateway Node.
 * Whenever a Service is annotated with a globalIp, creates an ingress rule to direct all traffic destined to the Service's globalIp to the
-  Service's `kube-proxy` IPTables chain which in turn directs traffic to Service's backend Pods.
+  Service's `kube-proxy` iptables chain which in turn directs traffic to Service's backend Pods.
 * On deletion of pod/service, clean up the rules from the gateway node.
 
 Globalnet currently relies on `kube-proxy` and thus will only work with deployments that use `kube-proxy`.

--- a/src/content/contributing/website/style_guide.md
+++ b/src/content/contributing/website/style_guide.md
@@ -17,6 +17,7 @@ wherever relevant. This is a Submariner-specific extension of those practices.
 A list of Submariner-specific terms and words to be used consistently across
 the site.
 
+<!-- markdownlint-disable line-length -->
 Term | Usage
 :--- | :----
 Admiral | The project name *Admiral* should always be capitalized.
@@ -25,11 +26,13 @@ ClusterSet | The Kubernetes object *ClusterSet* proposed in KEP1645 should alway
 Cluster set | The words "cluster set" should be used as a term for a group of clusters, but not the proposed Kubernetes object.
 Coastguard | The project name *Coastguard* should always be capitalized.
 Globalnet | The feature name *Globalnet* is one word, and so should always be capitalized and should have a lowercase "n".
+iptables | The application *iptables* consistently uses all-lowercase. Follow their convention, but avoid starting a sentence with "iptables".
 Lighthouse | The project name *Lighthouse* should always be capitalized.
 Operator | The design pattern *Operator* should always be capitalized.
 Shipyard | The project name *Shipyard* should always be capitalized.
 `subctl` | The artifact `subctl` should not be capitalized and should be formatted in code style.
 Submariner | The project name *Submariner* should always be capitalized.
+<!-- markdownlint-enable line-length -->
 
 ### Pronunciation of "Submariner"
 


### PR DESCRIPTION
The iptables application consistently uses all-lowercase as their proper
noun and therefore trademark. It seems we should follow their trademark,
but should do our best to avoid needing to start a sentence with
"iptables" and cause an inconsistency with other grammar norms. There
does not seem to be consensus about capitalizing words like this at the
beginning of sentences.

A summary of guidance to support this rule follows.

There does not seem to be any guidance for third-party application names
in the K8s Docs Style Guide:

https://kubernetes.io/docs/contribute/style/style-guide/

In the Fedora Manual for Technical Writers, there is guidance for
application names that are proper nouns

"When used as a proper name, use the capitalization of the product. When
used as a command, use lowercase as appropriate, such as ‘To start GCC,
type gcc’.
Note: ‘vi’ is always lowercase."

All-lowercase "iptables" is used elsewhere in that doc:

"For instructions on how to construct iptables rules... Less confusing"

There is also guidance for avoiding using always-lowercase words at the
beginning of sentences:

"hostname Correct. One word, lowercase. Capitalize when used at the
beginning of a sentence, but try to reword the sentence to avoid this."

https://rlandmann.fedorapeople.org/ossg/html-single/

On English StackExchange, an answer about trademark capitalization seems
to support following the "innovations in capitalization and punctuation
invented by trademark owners" but avoiding starting sentences with such
words when possible.

https://english.stackexchange.com/a/2942/159794

In the iptables manual, it is capitalized as the first word in the page
but not capitalized elsewhere, including at the start of subsequent
paragraphs and sentences.

https://linux.die.net/man/8/iptables

On Wikipedia, it's always lowercase, even at the start of sentences:

https://en.wikipedia.org/wiki/Iptables

Similar tools are also always lowercase on Wikipedia:

https://en.wikipedia.org/wiki/Nftables
https://en.wikipedia.org/wiki/Arptables

In the ArchLinux wiki, it's lowercase even at the start of sentences:

https://wiki.archlinux.org/index.php/Iptables

However, in the CentOS wiki, it's uppercase at the start of sentences:

https://wiki.centos.org/HowTos/Network/IPTables

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>