### PR TITLE
Decapitalize "kind", clarify in Style Guide

### DIFF
--- a/src/content/architecture/gateway-engine/_index.en.md
+++ b/src/content/architecture/gateway-engine/_index.en.md
@@ -55,5 +55,5 @@ Gateway node in the cluster.
 ![Figure 2 - Gateway Failover Scenario](/images/high-availability/HA_Cluster2.png)
 <!-- Image Source: https://docs.google.com/presentation/d/180CtHZnr9PP5Rh98VEmkQz3ovc5AGXG9wosoHMLhgaY/edit -->
 
-The impact on datapath for various scenarios in a KIND setup are captured in the
+The impact on datapath for various scenarios in a kind setup are captured in the
 following [spreadsheet](https://docs.google.com/spreadsheets/d/1JsXsyRDDXkp6t55Gm-NP5EggWTyYi2yo27pyuDYwlpc/edit#gid=0).

--- a/src/content/contributing/shipyard/_index.en.md
+++ b/src/content/contributing/shipyard/_index.en.md
@@ -6,7 +6,7 @@ weight: 80
 
 ## Overview
 
-The Shipyard project provides common tooling for creating K8s clusters with [KIND](https://github.com/kubernetes-sigs/kind) (K8s in Docker)
+The Shipyard project provides common tooling for creating K8s clusters with [kind](https://github.com/kubernetes-sigs/kind) (K8s in Docker)
 and provides a common Go framework for creating end to end tests.
 Shipyard contains common functionality shared by other projects. Any project specific functionality should be part of that project.
 
@@ -65,9 +65,9 @@ in the Shipyard directory. This creates a local image with your changes availabl
 
 Shipyard ships a [Makefile.inc] file which defines these basic targets:
 
-* **[clusters](#clusters):** Creates the KIND -based cluster environment.
+* **[clusters](#clusters):** Creates the kind -based cluster environment.
 * **[deploy](#deploy)** : Deploys submariner components in the cluster environment (depends on clusters).
-* **[cleanup](#cleanup):** Deletes the KIND environment (if it exists) and any residual resources.
+* **[cleanup](#cleanup):** Deletes the kind environment (if it exists) and any residual resources.
 * **[release](#release):** Uploads the requested image(s) to Quay.io.
 * **vendor/modules.txt:** Populates go modules (in case go.mod exists in the root directory).
 
@@ -78,7 +78,7 @@ precedence over environment variables).
 
 ### Clusters {#clusters}
 
-A Make target that creates a KIND-based multi-cluster environment with just the default K8s deployment:
+A Make target that creates a kind-based multi-cluster environment with just the default K8s deployment:
 
 ```shell
 make clusters
@@ -91,7 +91,7 @@ Respected variables:
 
 ### Deploy {#deploy}
 
-A Make target that deploys Submariner components in a KIND-based cluster environment (if one isn't created yet, this target will first
+A Make target that deploys Submariner components in a kind-based cluster environment (if one isn't created yet, this target will first
 invoke the clusters target to do so):
 
 ```shell
@@ -106,7 +106,7 @@ Respected variables:
 
 ### Cleanup {#cleanup}
 
-To clean up all the KIND clusters deployed in any of the previous steps, use:
+To clean up all the kind clusters deployed in any of the previous steps, use:
 
 ```shell
 make cleanup

--- a/src/content/contributing/shipyard/_index.en.md
+++ b/src/content/contributing/shipyard/_index.en.md
@@ -65,7 +65,7 @@ in the Shipyard directory. This creates a local image with your changes availabl
 
 Shipyard ships a [Makefile.inc] file which defines these basic targets:
 
-* **[clusters](#clusters):** Creates the kind -based cluster environment.
+* **[clusters](#clusters):** Creates the kind-based cluster environment.
 * **[deploy](#deploy)** : Deploys submariner components in the cluster environment (depends on clusters).
 * **[cleanup](#cleanup):** Deletes the kind environment (if it exists) and any residual resources.
 * **[release](#release):** Uploads the requested image(s) to Quay.io.

--- a/src/content/contributing/shipyard/advanced/_index.en.md
+++ b/src/content/contributing/shipyard/advanced/_index.en.md
@@ -89,7 +89,7 @@ same name). These flags affect how the clusters are deployed (and possibly influ
 
 Flags of note:
 
-* **k8s_version:** Allows to specify the K8s version that [KIND](https://kind.sigs.k8s.io/) will deploy. Available versions can be found
+* **k8s_version:** Allows to specify the K8s version that [kind](https://kind.sigs.k8s.io/) will deploy. Available versions can be found
   [here](https://hub.docker.com/r/kindest/node/tags).
 
   ```bash

--- a/src/content/contributing/website/style_guide.md
+++ b/src/content/contributing/website/style_guide.md
@@ -27,6 +27,7 @@ Cluster set | The words "cluster set" should be used as a term for a group of cl
 Coastguard | The project name *Coastguard* should always be capitalized.
 Globalnet | The feature name *Globalnet* is one word, and so should always be capitalized and should have a lowercase "n".
 iptables | The application *iptables* consistently uses all-lowercase. Follow their convention, but avoid starting a sentence with "iptables".
+kind | The tool *kind* consistently uses all-lowercase. Follow their convention, but avoid starting a sentence with "kind".
 Lighthouse | The project name *Lighthouse* should always be capitalized.
 Operator | The design pattern *Operator* should always be capitalized.
 Shipyard | The project name *Shipyard* should always be capitalized.

--- a/src/content/quickstart/kind/_index.md
+++ b/src/content/quickstart/kind/_index.md
@@ -1,12 +1,12 @@
 ---
 date: 2020-03-17T13:36:18+01:00
-title: "KIND (Local Environment)"
+title: "kind (Local Environment)"
 weight: 10
 ---
 
-## Deploy KIND+Submariner Locally
+## Deploy kind+Submariner Locally
 
-[KIND](https://github.com/kubernetes-sigs/kind) is a tool to run local Kubernetes clusters inside Docker container nodes.
+[kind](https://github.com/kubernetes-sigs/kind) is a tool to run local Kubernetes clusters inside Docker container nodes.
 
 Submariner provides (via [Shipyard](../../contributing/shipyard)) scripts that deploy 3 Kubernetes clusters locally - 1 Broker and 2 data
 clusters with the Submariner dataplane components deployed on all the clusters.
@@ -17,7 +17,7 @@ Docker must be installed and running on your computer.
 
 ### Deploy Automatically
 
-To create KIND clusters and deploy Submariner, run:
+To create kind clusters and deploy Submariner, run:
 
 ```bash
 git clone https://github.com/submariner-io/submariner
@@ -27,12 +27,12 @@ make deploy
 
 ### Deploy Manually
 
-If you wish to try out Submariner deployment manually, an easy option is to create KIND clusters using our scripts and deploy Submariner
+If you wish to try out Submariner deployment manually, an easy option is to create kind clusters using our scripts and deploy Submariner
 with [`subctl`](../../deployment/subctl).
 
-#### Create KIND Clusters
+#### Create kind Clusters
 
-To create KIND clusters, run:
+To create kind clusters, run:
 
 ```bash
 git clone https://github.com/submariner-io/submariner


### PR DESCRIPTION
Doc that "kind" is always lowercase

The kind project is very consistent in using lowercase throughout their
docs, including at the start of paragraphs and sentences.

https://kind.sigs.k8s.io/

Submariner should avoid starting a sentence with an always-lowercase
word to mitigate conflicts with other grammar norms.

The K8s Docs Docs don't provide guidance here, but see the iptables
commit message for other guidance and norms.

For example, in the Fedora Technical Writer's Guide, there's guidance
for avoiding using always-lowercase words at the beginning of sentences:

"hostname Correct. One word, lowercase. Capitalize when used at the
beginning of a sentence, but try to reword the sentence to avoid this."

https://rlandmann.fedorapeople.org/ossg/html-sing

In a second commit, make "kind" lowercase everywhere.