### PR TITLE
Add security reporting process

### DIFF
--- a/src/content/.well-known/security.txt
+++ b/src/content/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: submariner-security@googlegroups.com
+Preferred-Languages: en, es, fr
+Canonical: https://submariner.io/.well-known/security.txt
+Policy: https://submariner.io/contributing/security/
+Expires: Thu, 28 Oct 2021 00:00:00 -0000

--- a/src/content/contributing/security/_index.en.md
+++ b/src/content/contributing/security/_index.en.md
@@ -1,0 +1,12 @@
+---
+title: "Security Reporting"
+weight: 80
+---
+
+Submariner welcomes and appreciates responsible disclosure of security vulnerabilities.
+
+If you know of a security issue with Submariner, please report it to submariner-security@googlegroups.com.
+
+Submariner aspires to follow the [Kubernetes security reporting process](https://kubernetes.io/docs/reference/issues-security/security/),
+but is far too small of a project to implement those practices. Where applicable, Submariner will follow the principles of the Kubernetes
+process.

--- a/src/content/contributing/shipyard/_index.en.md
+++ b/src/content/contributing/shipyard/_index.en.md
@@ -1,7 +1,7 @@
 ---
 title: "Working With Shipyard"
 date: 2020-04-20T17:12:52+0300
-weight: 80
+weight: 90
 ---
 
 ## Overview

--- a/src/content/security.txt
+++ b/src/content/security.txt
@@ -1,0 +1,5 @@
+Contact: submariner-security@googlegroups.com
+Preferred-Languages: en, es, fr
+Canonical: https://submariner.io/security.txt
+Policy: https://submariner.io/contributing/security/
+Expires: Thu, 28 Oct 2021 00:00:00 -0000


### PR DESCRIPTION
Document Submariner's process for accepting reports of security
vulnerabilities.

Follow principles of K8s security process where applicable.

Closes: #110
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>