### PR TITLE
Fix curl command on kind quickstart

### DIFF
--- a/src/content/quickstart/kind/_index.md
+++ b/src/content/quickstart/kind/_index.md
@@ -105,5 +105,5 @@ Run `nettest` from `cluster2` to access the `nginx` service:
 ```bash
 kubectl --kubeconfig output/kubeconfigs/kind-config-cluster2 -n default  run --generator=run-pod/v1 \
 tmp-shell --rm -i --tty --image quay.io/submariner/nettest -- /bin/bash
-curl nginx.default.svc.clusterset.local:8080
+curl nginx.default.svc.clusterset.local
 ```


### PR DESCRIPTION
On kind, we expose the nginx test service on port 80 and not 8080; fixed the `curl` command accordingly, otherwise the verification step is broken.

Signed-off-by: nyechiel <n.yechiel@gmail.com>