### PR TITLE
Clean up Code of Conduct, fix GH group

### DIFF
--- a/src/content/contributing/code-of-conduct/_index.en.md
+++ b/src/content/contributing/code-of-conduct/_index.en.md
@@ -8,10 +8,8 @@ weight: 20
 
 Submariner follows the [CNCF Code of Conduct][cncf coc].
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting one or more of the Submariner [Committers][committers]
-or [Owners][owners].
+Please report instances of abusive, harassing, or otherwise unacceptable behavior by contacting one or more of the Submariner [Project
+Owners][owners].
 
 [cncf coc]: https://github.com/cncf/foundation/blob/bec34a2614c980f8cfe38b18105e0baa820936cc/code-of-conduct.md
-[committers]: https://submariner-io.github.io/contributing/community-membership/#committers
-[owners]: https://github.com/orgs/submariner-io/teams/submariner-core/members
+[owners]: https://github.com/orgs/submariner-io/teams/submariner-owners/members


### PR DESCRIPTION
Various minor cleanups of the Code of Conduct docs.

* Now that we have 4 Project Owners, clarify reporting process by only
  mentioning them vs harder-to-track-down Committers too.
* Link to updated Owners group, name has changed.
* Improve wording to more clearly imply that we want reports, not only
  that they are accepted.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>