### PR TITLE
Clarify that Service Discovery is on by default

### DIFF
--- a/src/content/architecture/_index.en.md
+++ b/src/content/architecture/_index.en.md
@@ -10,13 +10,13 @@ The diagram below illustrates the basic architecture of Submariner:
 ![Submariner Architecture](/images/submariner/architecture.jpg)
 
 Submariner consists of several main components that work in conjunction to securely connect workloads across multiple Kubernetes clusters,
-both on-premises and on public clouds.
+both on-premises and on public clouds:
 
 * [Gateway Engine](./gateway-engine/): manages the secure tunnels to other clusters.
 * [Route Agent](./route-agent/): routes cross-cluster traffic from nodes to the active Gateway Engine.
 * [Broker](./broker/): facilitates the exchange of metadata between Gateway Engines enabling them to discover one another.
+* [Service Discovery](./service-discovery/): provides DNS discovery of Services across clusters.
 
-Submariner has optional components that provide additional functionality.
+Submariner has optional components that provide additional functionality:
 
-* [Globalnet Controller](./globalnet/): handles overlapping CIDRs across clusters.
-* [Service Discovery](./service-discovery/): provides DNS discovery of services across clusters.
+* [Globalnet Controller](./globalnet/): handles interconnection of clusters with overlapping CIDRs.

--- a/src/content/architecture/globalnet/_index.en.md
+++ b/src/content/architecture/globalnet/_index.en.md
@@ -1,7 +1,7 @@
 +++
 title = "Globalnet Controller"
 date = 2020-02-19T21:08:37+01:00
-weight = 4
+weight = 5
 +++
 
 ## Introduction

--- a/src/content/architecture/service-discovery/_index.en.md
+++ b/src/content/architecture/service-discovery/_index.en.md
@@ -1,7 +1,7 @@
 ---
 title: "Service Discovery"
 date: 2020-03-02T21:25:35+01:00
-weight: 5
+weight: 4
 ---
 
 The Lighthouse project provides DNS discovery for Kubernetes clusters connected by


### PR DESCRIPTION
Lighthouse is a mature component of Submariner now and we need our docs to reflect that.

Signed-off-by: nyechiel <nyechiel@redhat.com>