### PR TITLE
Fix kubectl describe serviceexport command

### DIFF
--- a/src/content/troubleshooting/_index.en.md
+++ b/src/content/troubleshooting/_index.en.md
@@ -87,7 +87,7 @@ For a Service to be accessible across clusters, you must first export the Servic
 Ensure the `ServiceExport` resource exists and check if its status condition indicates `Exported'. Otherwise, its status condition will
 indicate the reason it wasn't exported.
 
-`kubectl get serviceexport -n <service-namespace> <service-name>`
+`kubectl describe serviceexport -n <service-namespace> <service-name>`
 
 Sample output:
 


### PR DESCRIPTION
Change `kubectl **get** serviceexport -n <service-namespace> <service-name>`  to  `kubectl **describe** serviceexport -n <service-namespace> <service-name>` to match the output in the doc

Signed-off-by: nyechiel <nyechiel@redhat.com>