### PR TITLE
Added missing 'subctl export' to StatefulSet verification code

### DIFF
--- a/src/content/quickstart/verify_with_discovery.md
+++ b/src/content/quickstart/verify_with_discovery.md
@@ -84,11 +84,12 @@ spec:
           name: web
 ```
 
-Use this yaml to create a StatefulSet `web` with `nginx-ss` as the headless Service.
+Use this yaml to create a StatefulSet `web` with `nginx-ss` as the Headless Service.
 
 ```bash
 export KUBECONFIG=cluster-a/auth/kubeconfig
-kubectl -n default  apply -f web.yaml
+kubectl -n default apply -f web.yaml
+subctl export service -n default nginx-ss
 curl nginx-ss.default.svc.clusterset.local:8080
 ```
 


### PR DESCRIPTION
Signed-off-by: Laura Henning <laura-marie.henning@stud.h-da.de>

I noticed the Service created with the StatefulSet was not exported to Submariner in the example code, so I added the line.