### PR TITLE
Fix subctl cluster-ids in Globalnet quickstart

### DIFF
--- a/src/content/quickstart/openshift/globalnet/_index.md
+++ b/src/content/quickstart/openshift/globalnet/_index.md
@@ -91,11 +91,11 @@ subctl deploy-broker  --kubeconfig cluster-a/auth/kubeconfig --service-discovery
 #### Join cluster-a and cluster-b to the Broker
 
 ```bash
-subctl join --kubeconfig cluster-a/auth/kubeconfig broker-info.subm --clusterid west
+subctl join --kubeconfig cluster-a/auth/kubeconfig broker-info.subm --clusterid cluster-a
 ```
 
 ```bash
-subctl join --kubeconfig cluster-b/auth/kubeconfig broker-info.subm --clusterid east
+subctl join --kubeconfig cluster-b/auth/kubeconfig broker-info.subm --clusterid cluster-b
 ```
 
 {{< include "quickstart/verify_with_discovery.md" >}}


### PR DESCRIPTION
Use **cluster-a** and **cluster-b** to be consistent with the rest of the guide.

Signed-off-by: nyechiel <nyechiel@redhat.com>