### PR TITLE
Adjust the monitoring documentation for OpenShift 4.6

### DIFF
--- a/src/content/operations/monitoring/_index.en.md
+++ b/src/content/operations/monitoring/_index.en.md
@@ -24,9 +24,11 @@ The following metrics are exposed currently:
 ### OpenShift setup
 
 OpenShift 4.5 or later can automatically discover the Submariner metrics.
-This currently requires enabling user workload monitoring; see
-[the OpenShift documentation](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/monitoring/monitoring-your-own-services)
-for details.
+This requires enabling user workload monitoring; see the
+[OpenShift 4.5](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/monitoring/monitoring-your-own-services)
+or
+[OpenShift 4.6](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/monitoring/enabling-monitoring-for-user-defined-projects)
+documentation for details.
 
 ### Prometheus Operator
 


### PR DESCRIPTION
User workload monitoring is fully supported in 4.6 but not enabled by
default; adjust the documentation accordingly and add a link to the
4.6 documentation.

Signed-off-by: Stephen Kitt <skitt@redhat.com>