### PR TITLE
Fix broken URL on kind quickstart

### DIFF
--- a/src/content/getting_started/quickstart/kind/_index.md
+++ b/src/content/getting_started/quickstart/kind/_index.md
@@ -32,7 +32,7 @@ the Broker. See the [cluster-settings](https://github.com/submariner-io/submarin
 ### Deploy Manually
 
 If you wish to try out Submariner deployment manually, an easy option is to create kind clusters using our scripts and deploy Submariner
-with [`subctl`](/operations/deployment/subctl).
+with [`subctl`](../../../operations/deployment/subctl).
 
 #### Create kind Clusters
 

--- a/src/content/getting_started/quickstart/kind/_index.md
+++ b/src/content/getting_started/quickstart/kind/_index.md
@@ -32,7 +32,7 @@ the Broker. See the [cluster-settings](https://github.com/submariner-io/submarin
 ### Deploy Manually
 
 If you wish to try out Submariner deployment manually, an easy option is to create kind clusters using our scripts and deploy Submariner
-with [`subctl`](../../deployment/subctl).
+with [`subctl`](/operations/deployment/subctl).
 
 #### Create kind Clusters
 


### PR DESCRIPTION
As found by https://github.com/submariner-io/submariner-website/runs/1468619608?check_suite_focus=true

Signed-off-by: nyechiel <nyechiel@redhat.com>