### PR TITLE
Fix broken links

### DIFF
--- a/src/content/community/roadmap/_index.en.md
+++ b/src/content/community/roadmap/_index.en.md
@@ -39,5 +39,5 @@ Some high-level goals are summarized here, but the primary source for tracking f
 If we are missing something that would make Submariner more useful to you, please let us know. The best way is to file an Issue and include
 information on how you intend to use Submariner with that feature.
 
-[cal]: https://submariner.io/contributing/#community-calendarhttpscalendargooglecomcalendarrcidnhfuzgvoogy0bzz1ajlvznbsczh1nwnlz2taz3jvdxauy2fszw5kyxiuz29vz2xllmnvbq
+[cal]: https://calendar.google.com/calendar?cid=NHFuZGVoOGY0bzZ1ajlvZnBsczh1NWNlZ2tAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ
 [projects]: https://github.com/orgs/submariner-io/projects

--- a/src/content/for_developers/community-membership/_index.en.md
+++ b/src/content/for_developers/community-membership/_index.en.md
@@ -195,7 +195,7 @@ The following apply to people who would be an owner:
 [parent process]: https://github.com/kubernetes/community/blob/7d2ebad43cde06607cde3d55e9eed4bb08a286a9/community-membership.md
 [code reviews]: https://github.com/kubernetes/community/blob/7d2ebad43cde06607cde3d55e9eed4bb08a286a9/contributors/guide/collab.md
 [community expectations]: https://github.com/kubernetes/community/blob/7d2ebad43cde06607cde3d55e9eed4bb08a286a9/contributors/guide/expectations.md
-[contributor guide]: https://submariner-io.github.io/contributing/
+[contributor guide]: ../dev_guide
 [Submariner org]: https://github.com/submariner
 [submariner-dev@googlegroups.com]: https://groups.google.com/forum/#!forum/submariner-dev
 [membership request issue]: https://github.com/submariner-io/submariner/issues/new?template=membership.md&title=REQUEST%3A%20New%20membership%20request%20for%20%3Cyour-GH-handle%3E


### PR DESCRIPTION
Fixes #395

As reported by the MD link job. The two links in **src/content/reading_material/_index.en.md**_ are valid, perhaps they
were unavailable at the time the job ran.
