### PR TITLE
Document that only 'subctl benchmark latency' is not compatible with …

### DIFF
--- a/src/content/operations/known-issues/_index.en.md
+++ b/src/content/operations/known-issues/_index.en.md
@@ -22,4 +22,4 @@ Currently, Submariner does not support using [custom `ikeport` and `nattport`](.
 * Globalnet annotates every Service in a cluster at the moment, whether or not it was exported.
 * Gateway Health Check is not available for Globalnet deployments at this time.
 * Currently, Globalnet is not supported with the OVN network plug-in.
-* The `subctl benchmark` command is not compatible with Globalnet deployments at this time.
+* The `subctl benchmark latency` command is not compatible with Globalnet deployments at this time.


### PR DESCRIPTION
…globalnet

Signed-off-by: Maayan Friedman <maafried@redhat.com>