### PR TITLE
Rebuild all the content, including stable branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,11 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Build the website static files
-        run: make static
+        run: make static-all
 
       - name: Upload proposed static website for review
         uses: actions/upload-artifact@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - 'release-*'
 
 jobs:
   publish:
@@ -13,6 +14,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Create secret key to git push
         run: |
@@ -27,8 +30,8 @@ jobs:
         env:
           GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
 
-      - name: Build the website static files
-        run: make static
+      - name: Build the website static files for each release
+        run: make static-all
 
       - name: Push the updated static files
         run: ./scripts/publish

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 URL := http://localhost:1313
 OPEN_CMD := $(shell command -v open || command -v xdg-open || echo : 2>/dev/null)
 HUGO_VERSION := v0.71.0
+OUTPUT_DIR:=/
 
 hugo:
 	@echo Downloading hugo wrapper 
@@ -13,7 +14,10 @@ server: hugo
 	./hugo server -w -s src
 
 static: hugo
-	./hugo -D -s src -d ../output
+	./hugo -D -s src -b $(OUTPUT_DIR) -d ../output/$(OUTPUT_DIR)
+
+static-all: hugo
+	./scripts/make-all-versions # we use a script because we expect that changes could happen on makefiles
 
 
 .DEFAULT_GOAL := static 

--- a/scripts/make-all-versions
+++ b/scripts/make-all-versions
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -ex
+
+git checkout master
+make static
+RELEASES=$(git for-each-ref --format='%(refname)' refs/heads/ | awk -F/ '/release/ { print $NF }' )
+for release in $RELEASES; do
+    VERSION=${release#release-}
+    git checkout $release
+    make static OUTPUT_DIR="${VERSION}/"        
+done


### PR DESCRIPTION
This will render the master version on the base of the
website "/", while stable releases will be rendered as:

 /0.8/ /0.9/ /0.10/ ... etc ..

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>