### PR TITLE
[release-0.8] stable release backports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,11 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Build the website static files
-        run: make static
+        run: make static-all
 
       - name: Upload proposed static website for review
         uses: actions/upload-artifact@v1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -32,6 +32,7 @@ jobs:
           config-file: ".markdownlinkcheck.json"
           check-modified-files-only: "yes"
           folder-path: "src/content"
+          base-branch: ${{ github.base_ref }}
 
   markdownlint:
     name: Markdown

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - 'release-*'
 
 jobs:
   publish:
@@ -13,6 +14,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Create secret key to git push
         run: |
@@ -27,8 +30,8 @@ jobs:
         env:
           GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
 
-      - name: Build the website static files
-        run: make static
+      - name: Build the website static files for each release
+        run: make static-all
 
       - name: Push the updated static files
         run: ./scripts/publish

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 URL := http://localhost:1313
 OPEN_CMD := $(shell command -v open || command -v xdg-open || echo : 2>/dev/null)
 HUGO_VERSION := v0.71.0
+OUTPUT_DIR:=/
 
 hugo:
 	@echo Downloading hugo wrapper 
@@ -13,7 +14,10 @@ server: hugo
 	./hugo server -w -s src
 
 static: hugo
-	./hugo -D -s src -d ../output
+	./hugo -D -s src -b $(OUTPUT_DIR) -d ../output/$(OUTPUT_DIR)
+
+static-all: hugo
+	./scripts/make-all-versions # we use a script because we expect that changes could happen on makefiles
 
 
 .DEFAULT_GOAL := static 

--- a/scripts/make-all-versions
+++ b/scripts/make-all-versions
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -ex
+
+git checkout master
+make static
+RELEASES=$(git for-each-ref --format='%(refname)' refs/heads/ | awk -F/ '/release/ { print $NF }' )
+for release in $RELEASES; do
+    VERSION=${release#release-}
+    git checkout $release
+    make static OUTPUT_DIR="${VERSION}/"        
+done

--- a/scripts/make-all-versions
+++ b/scripts/make-all-versions
@@ -4,7 +4,7 @@ set -ex
 
 git checkout master
 make static
-RELEASES=$(git for-each-ref --format='%(refname)' refs/heads/ | awk -F/ '/release/ { print $NF }' )
+RELEASES=$(git for-each-ref --format='%(refname)' refs/remotes/origin | awk -F/ '/release/ { print $NF }' )
 for release in $RELEASES; do
     VERSION=${release#release-}
     git checkout $release

--- a/src/content/operations/known-issues/_index.en.md
+++ b/src/content/operations/known-issues/_index.en.md
@@ -20,6 +20,5 @@ Currently, Submariner does not support using [custom `ikeport` and `nattport`](.
 * Globalnet only supports Pod to remote Service connectivity using Global IPs. Pod to Pod connectivity is not supported at this time.
 * Globalnet is not compatible with Headless Services. Only ClusterIP Services are supported at this time.
 * Globalnet annotates every Service in a cluster at the moment, whether or not it was exported.
-* Gateway Health Check is not available for Globalnet deployments at this time.
 * Currently, Globalnet is not supported with the OVN network plug-in.
 * The `subctl benchmark latency` command is not compatible with Globalnet deployments at this time.

--- a/src/content/operations/known-issues/_index.en.md
+++ b/src/content/operations/known-issues/_index.en.md
@@ -22,4 +22,4 @@ Currently, Submariner does not support using [custom `ikeport` and `nattport`](.
 * Globalnet annotates every Service in a cluster at the moment, whether or not it was exported.
 * Gateway Health Check is not available for Globalnet deployments at this time.
 * Currently, Globalnet is not supported with the OVN network plug-in.
-* The `subctl benchmark` command is not compatible with Globalnet deployments at this time.
+* The `subctl benchmark latency` command is not compatible with Globalnet deployments at this time.

--- a/src/content/operations/monitoring/_index.en.md
+++ b/src/content/operations/monitoring/_index.en.md
@@ -20,6 +20,11 @@ The following metrics are exposed currently:
 
 * `submariner_gateways`: the number of gateways in the cluster
 
+* `submariner_gateway_creation_timestamp`: timestamp of gateway creation time, with the following labels:
+
+  * `local_cluster`: the local cluster name
+  * `local_hostname`: the local hostname
+
 * `submariner_connections`: the number of connections to other clusters, with the following labels:
 
   * `local_cluster`: the local cluster name

--- a/src/content/other-resources/_index.en.md
+++ b/src/content/other-resources/_index.en.md
@@ -36,5 +36,9 @@ There are multiple presentations and demo recordings about Submariner available 
 1. [SIG Multicluster demo of Submariner's KEP1645 Multicluster Services implementation (2020/09/22)](https://youtu.be/bx4z9sMX8FM?t=1350)
 2. [SIG Multicluster demo of Submariner's multicluster networking deployed by Submariner's Operator and `subctl` (2019/12/17)](https://youtu.be/4C4kc9AOz4M?t=273)
 
+## Academic Papers
+
+1. [Kubernetes and the Edge?](https://hal.inria.fr/hal-02972686/document)
+
 If you find additional material that isn't listed here, please feel free to add it to this page by editing it.
 The website contributing guide is [here](../development/website).


### PR DESCRIPTION
Backports the following commits to release-0.8:
 - List all the remote branches when building the site (#419)
 - Link to academic paper partly-about Submariner (#404)
 - Document that only 'subctl benchmark latency' is not compatible with globalnet (#408)
 - Document new metric: submariner_gateway_creation_timestamp (#409)
 - Update Globalnet Healthcheck support status (#414)
 - Use the PR base branch as reference when linting (#417)
 - Rebuild all the content, including stable branches (#416)
