### PR TITLE
List all the remote branches when building the site

### DIFF
--- a/scripts/make-all-versions
+++ b/scripts/make-all-versions
@@ -4,7 +4,7 @@ set -ex
 
 git checkout master
 make static
-RELEASES=$(git for-each-ref --format='%(refname)' refs/heads/ | awk -F/ '/release/ { print $NF }' )
+RELEASES=$(git for-each-ref --format='%(refname)' refs/remotes/origin | awk -F/ '/release/ { print $NF }' )
 for release in $RELEASES; do
     VERSION=${release#release-}
     git checkout $release


### PR DESCRIPTION
Otherwise it will only find locally checked out branches,
which doesn't work in CI.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>