### PR TITLE
[release-0.8] Fix baseURL for stable releases (#420)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ server: hugo
 	./hugo server -w -s src
 
 static: hugo
-	./hugo -D -s src -b $(OUTPUT_DIR) -d ../output/$(OUTPUT_DIR)
+	./hugo -D -s src -b $(OUTPUT_DIR) -d ../output$(OUTPUT_DIR)
 
 static-all: hugo
 	./scripts/make-all-versions # we use a script because we expect that changes could happen on makefiles

--- a/scripts/make-all-versions
+++ b/scripts/make-all-versions
@@ -8,5 +8,5 @@ RELEASES=$(git for-each-ref --format='%(refname)' refs/remotes/origin | awk -F/ 
 for release in $RELEASES; do
     VERSION=${release#release-}
     git checkout $release
-    make static OUTPUT_DIR="${VERSION}/"        
+    make static OUTPUT_DIR="/${VERSION}/"
 done


### PR DESCRIPTION
Backports the following commits to release-0.8:
 - Fix baseURL for stable releases (#420)