### PR TITLE
Change cluster name to b

### DIFF
--- a/src/resources/shared/verify_with_discovery.md
+++ b/src/resources/shared/verify_with_discovery.md
@@ -35,7 +35,7 @@ curl nginx.default.svc.clusterset.local:8080
 To access a Service in a specific cluster, prefix the query with `<cluster-id>` as follows:
 
 ```bash
-curl cluster-a.nginx.default.svc.clusterset.local:8080
+curl cluster-b.nginx.default.svc.clusterset.local:8080
 ```
 
 #### Verify StatefulSets


### PR DESCRIPTION
nginx is deployed on cluster-b. curl on cluster-b
instead of cluster-a for easy copy and paste.

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>