### PR TITLE
Update Helm docs to use submariner-operator chart

### DIFF
--- a/src/content/operations/deployment/helm/_index.en.md
+++ b/src/content/operations/deployment/helm/_index.en.md
@@ -19,8 +19,8 @@ helm repo add submariner-latest https://submariner-io.github.io/submariner-chart
 
 ```bash
 export BROKER_NS=submariner-k8s-broker
+export SUBMARINER_NS=submariner-operator
 export SUBMARINER_PSK=$(LC_CTYPE=C tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 64 | head -n 1)
-export SUBMARINER_NS=submariner
 ```
 
 ### Deploying the Broker
@@ -35,13 +35,13 @@ helm install "${BROKER_NS}" submariner-latest/submariner-k8s-broker \
 Setup more environment variables we will need later for joining clusters.
 
 ```bash
-export SUBMARINER_BROKER_URL=$(kubectl -n default get endpoints kubernetes \
-    -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")
 export SUBMARINER_BROKER_CA=$(kubectl -n "${BROKER_NS}" get secrets \
     -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='${BROKER_NS}-client')].data['ca\.crt']}")
 export SUBMARINER_BROKER_TOKEN=$(kubectl -n "${BROKER_NS}" get secrets \
     -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='${BROKER_NS}-client')].data.token}" \
        | base64 --decode)
+export SUBMARINER_BROKER_URL=$(kubectl -n default get endpoints kubernetes \
+    -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")
 ```
 
 ### Joining a cluster
@@ -66,7 +66,7 @@ export GLOBAL_CIDR=169.254.x.x/x # using an individual non-overlapping
 Joining the cluster:
 
 ```bash
-helm install submariner submariner-latest/submariner \
+helm install submariner-operator submariner-latest/submariner-operator \
         --create-namespace \
         --namespace "${SUBMARINER_NS}" \
         --set ipsec.psk="${SUBMARINER_PSK}" \
@@ -74,13 +74,14 @@ helm install submariner submariner-latest/submariner \
         --set broker.token="${SUBMARINER_BROKER_TOKEN}" \
         --set broker.namespace="${BROKER_NS}" \
         --set broker.ca="${SUBMARINER_BROKER_CA}" \
+        --set submariner.cableDriver=libreswan \ # or wireguard
         --set submariner.clusterId="${CLUSTER_ID}" \
         --set submariner.clusterCidr="${CLUSTER_CIDR}" \
         --set submariner.serviceCidr="${SERVICE_CIDR}" \
         --set submariner.globalCidr="${GLOBAL_CIDR}" \
         --set serviceAccounts.globalnet.create="${GLOBALNET}" \
         --set submariner.natEnabled="true" \  # disable this if no NAT will happen between gateways
-        --set crd.create=true \
+        --set brokercrd.create=false \
         --set submariner.serviceDiscovery=true \
         --set serviceAccounts.lighthouse.create=true
 ```
@@ -88,16 +89,9 @@ helm install submariner submariner-latest/submariner \
 Some image override settings you could use
 
 ```bash
-        --set globalnet.image.repository="localhost:5000/submariner-globalnet" \
-        --set globalnet.image.tag="local" \
-        --set globalnet.image.pullPolicy="IfNotPresent" \
-        --set engine.image.repository="localhost:5000/submariner" \
-        --set engine.image.tag="local" \
-        --set engine.image.pullPolicy="IfNotPresent" \
-        --set routeAgent.image.repository="localhost:5000/submariner-route-agent" \
-        --set routeAgent.image.tag="local" \
-        --set routeAgent.image.pullPolicy="IfNotPresent" \
-        --set lighthouse.image.repository=localhost:5000/lighthouse-agent
+        --set operator.image.repository="localhost:5000/submariner-operator" \
+        --set operator.image.tag="local" \
+        --set operator.image.pullPolicy="IfNotPresent"
 ```
 
 If installing on OpenShift, please also add the Submariner service accounts (SAs) to the


### PR DESCRIPTION
Update the Helm deployment docs use the new submariner-operator Helm
chart that deploys the operator to in turn deploy and manage Submariner.

Also minor re-ordering of variables to be alphabetical.

Closes: #440
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>