### PR TITLE
Docs: prefix all metrics with submariner_

### DIFF
--- a/src/content/operations/monitoring/_index.en.md
+++ b/src/content/operations/monitoring/_index.en.md
@@ -30,9 +30,12 @@ The following metrics are exposed currently:
 * `submariner_gateway_tx_bytes`: count of bytes transmitted by cable driver and cable (labels: `cable_driver`, `local_cluster`,
 `local_hostname`, `local_endpoint_ip`, `remote_cluster`, `remote_hostname`, `remote_endpoint_ip`)
 
+* `submariner_requested_connections`: the number of connections by endpoint and status (labels: `local_cluster`, `local_hostname`,
+`remote_cluster`, `remote_hostname`, `status`: “connecting”, “connected”, or “error”)
+
 * `submariner_connections`: the number of connections and corresponding status by cable driver and cable
 (labels: `cable_driver`, `local_cluster`, `local_hostname`, `local_endpoint_ip`, `remote_cluster`, `remote_hostname`, `remote_endpoint_ip`,
-`status`)
+`status`: “connecting”, “connected”, or “error”)
 
 * `submariner_connection_established_timestamp`: timestamp of last successful connection established by cable driver and cable
 (labels: `cable_driver`, `local_cluster`, `local_hostname`, `local_endpoint_ip`, `remote_cluster`, `remote_hostname`, `remote_endpoint_ip`)

--- a/src/content/operations/monitoring/_index.en.md
+++ b/src/content/operations/monitoring/_index.en.md
@@ -20,38 +20,27 @@ The following metrics are exposed currently:
 
 * `submariner_gateways`: the number of gateways in the cluster
 
-* `submariner_gateway_creation_timestamp`: timestamp of gateway creation time, with the following labels:
+* `submariner_gateway_creation_timestamp`: timestamp of gateway creation time (labels: `local_cluster`, `local_hostname`)
 
-  * `local_cluster`: the local cluster name
-  * `local_hostname`: the local hostname
+* `submariner_gateway_rx_bytes`: count of bytes received by cable driver and cable (labels: `cable_driver`, `local_cluster`,
+`local_hostname`, `local_endpoint_ip`, `remote_cluster`, `remote_hostname`, `remote_endpoint_ip`)
 
-* `submariner_connections`: the number of connections to other clusters, with the following labels:
+* `submariner_gateway_tx_bytes`: count of bytes transmitted by cable driver and cable (labels: `cable_driver`, `local_cluster`,
+`local_hostname`, `local_endpoint_ip`, `remote_cluster`, `remote_hostname`, `remote_endpoint_ip`)
 
-  * `local_cluster`: the local cluster name
-  * `local_hostname`: the local hostname
-  * `remote_cluster`: the remote cluster name
-  * `remote_hostname`: the remote hostname
-  * `status`: the connection status (“connecting”, “connected”, or “error”)
-
-* `gateway_rx_bytes`: count of bytes received by cable driver and cable (labels: `cable_driver`, `local_cluster`, `local_hostname`,
-`local_endpoint_ip`, `remote_cluster`, `remote_hostname`, `remote_endpoint_ip`)
-
-* `gateway_tx_bytes`: count of bytes transmitted by cable driver and cable (labels: `cable_driver`, `local_cluster`, `local_hostname`,
-`local_endpoint_ip`, `remote_cluster`, `remote_hostname`, `remote_endpoint_ip`)
-
-* `connection_established_timestamp`: timestamp of last successful connection established by cable driver and cable
-(labels: `cable_driver`, `local_cluster`, `local_hostname`, `local_endpoint_ip`, `remote_cluster`, `remote_hostname`, `remote_endpoint_ip`)
-
-* `connection_latency_seconds`: connection latency in seconds; last RTT, by cable driver and cable
-(labels: `cable_driver`, `local_cluster`, `local_hostname`, `local_endpoint_ip`, `remote_cluster`, `remote_hostname`, `remote_endpoint_ip`)
-
-* `connections`: the number of connections and corresponding status by cable driver and cable
+* `submariner_connections`: the number of connections and corresponding status by cable driver and cable
 (labels: `cable_driver`, `local_cluster`, `local_hostname`, `local_endpoint_ip`, `remote_cluster`, `remote_hostname`, `remote_endpoint_ip`,
 `status`)
 
-* `global_IP_availability`: count of available global IPs per CIDR (labels: `cidr`)
+* `submariner_connection_established_timestamp`: timestamp of last successful connection established by cable driver and cable
+(labels: `cable_driver`, `local_cluster`, `local_hostname`, `local_endpoint_ip`, `remote_cluster`, `remote_hostname`, `remote_endpoint_ip`)
 
-* `global_IP_allocated`: count of global IPs allocated for Pods/Services per CIDR (labels: `cidr`)
+* `submariner_connection_latency_seconds`: connection latency in seconds; last RTT, by cable driver and cable
+(labels: `cable_driver`, `local_cluster`, `local_hostname`, `local_endpoint_ip`, `remote_cluster`, `remote_hostname`, `remote_endpoint_ip`)
+
+* `submariner_global_IP_availability`: count of available global IPs per CIDR (labels: `cidr`)
+
+* `submariner_global_IP_allocated`: count of global IPs allocated for Pods/Services per CIDR (labels: `cidr`)
 
 ### Prometheus Operator
 

--- a/src/content/operations/monitoring/_index.en.md
+++ b/src/content/operations/monitoring/_index.en.md
@@ -22,6 +22,8 @@ The following metrics are exposed currently:
 
 * `submariner_gateway_creation_timestamp`: timestamp of gateway creation time (labels: `local_cluster`, `local_hostname`)
 
+* `submariner_gateway_sync_iterations`: gateway synchronization iterations
+
 * `submariner_gateway_rx_bytes`: count of bytes received by cable driver and cable (labels: `cable_driver`, `local_cluster`,
 `local_hostname`, `local_endpoint_ip`, `remote_cluster`, `remote_hostname`, `remote_endpoint_ip`)
 


### PR DESCRIPTION
Prefix all metrics with "submariner_" as per https://github.com/submariner-io/submariner/pull/1143.

Also removed redundant information about "submariner_connections" and did minor style changes for consistency.  

Signed-off-by: nyechiel <nyechiel@redhat.com>