### PR TITLE
ServiceExport changes for Globalnet

### DIFF
--- a/src/content/community/roadmap/_index.en.md
+++ b/src/content/community/roadmap/_index.en.md
@@ -28,7 +28,6 @@ Some high-level goals are summarized here, but the primary source for tracking f
 * Network Policy across clusters (Coastguard)
 * Support for finer-grained connectivity policies (<https://github.com/submariner-io/submariner/issues/533>)
 * Globalnet: annotating Global IPs per namespaces (<https://github.com/submariner-io/submariner/issues/528>)
-* Globalnet: only annotate Services for which a ServiceExport has been created (<https://github.com/submariner-io/submariner/issues/652>)
 * More tunnel encapsulation options
 * Dynamic routing with BGP to support multi-path forwarding across gateways
 * Testing with multi-cluster Istio

--- a/src/content/getting-started/architecture/globalnet/_index.en.md
+++ b/src/content/getting-started/architecture/globalnet/_index.en.md
@@ -29,7 +29,7 @@ the cluster, the supplied globalnet-cidr will be ignored.
 
 Once configured, each exported Service and Pod that requires cross-cluster access is allocated an IP, named `globalIp`,
 from this `GlobalCIDR` that is annotated on the Pod/Service object.
-This globalIp is used for allcross-cluster communication to and from a Pod and the globalIp of a
+This globalIp is used for all cross-cluster communication to and from a Pod and the globalIp of a
 remote Service. Routing and iptable rules are configured to use the globalIp for ingress and egress. All address translations occur on the
 Gateway node.
 
@@ -69,7 +69,7 @@ This component is responsible for programming the routing entries, iptable rules
   on the Gateway Node.
 * Whenever a Service is annotated with a globalIp, creates an ingress rule to direct all traffic destined to the Service's globalIp to the
   Service's `kube-proxy` iptables chain which in turn directs traffic to Service's backend Pods.
-* On deletion of pod/service, clean up the rules from the gateway node.
+* On deletion of Pod, Service or ServiceExport, clean up the rules from the gateway node.
 
 Globalnet currently relies on `kube-proxy` and thus will only work with deployments that use `kube-proxy`.
 

--- a/src/content/getting-started/architecture/globalnet/_index.en.md
+++ b/src/content/getting-started/architecture/globalnet/_index.en.md
@@ -56,9 +56,9 @@ It mainly consists of two key components: the IP Address Manager and Globalnet.
 The IP Address Manager (IPAM) component does the following:
 
 * Creates a pool of IP addresses based on the `GlobalCIDR` configured on cluster.
-* On creation of a Pod, or export of a Service, allocates a globalIp from the GlobalIp pool.
+* Allocates a globalIp from the GlobalIp pool on creation of a Pod, Service, or ServiceExport.
 * Annotates the Pod or exported Service with `submariner.io/globalIp=<global-ip>`.
-* On deletion of a Pod, Service or ServiceExport, releases its globalIp back to the pool.
+* On deletion of a Pod, Service, or ServiceExport, releases its globalIp back to the pool.
 
 #### Globalnet
 
@@ -69,7 +69,7 @@ This component is responsible for programming the routing entries, iptable rules
   on the Gateway Node.
 * Whenever a Service is annotated with a globalIp, creates an ingress rule to direct all traffic destined to the Service's globalIp to the
   Service's `kube-proxy` iptables chain which in turn directs traffic to Service's backend Pods.
-* On deletion of Pod, Service or ServiceExport, clean up the rules from the gateway node.
+* Clean up the rules from the gateway node on the deletion of a Pod, Service, or ServiceExport.
 
 Globalnet currently relies on `kube-proxy` and thus will only work with deployments that use `kube-proxy`.
 

--- a/src/content/getting-started/architecture/globalnet/_index.en.md
+++ b/src/content/getting-started/architecture/globalnet/_index.en.md
@@ -27,8 +27,9 @@ configurable at time of deployment. User can also manually specify GlobalCIDR fo
 ```globalnet-cidr``` passed to ```subctl join``` command. If Globalnet is not enabled in the Broker or if a GlobalCIDR is preconfigured in
 the cluster, the supplied globalnet-cidr will be ignored.
 
-Once configured, each Service and Pod that requires cross-cluster access is allocated an IP, named `globalIp`, from this `GlobalCIDR` that
-is annotated on the Pod/Service object. This globalIp is used for all cross-cluster communication to and from a Pod and the globalIp of a
+Once configured, each exported Service and Pod that requires cross-cluster access is allocated an IP, named `globalIp`,
+from this `GlobalCIDR` that is annotated on the Pod/Service object.
+This globalIp is used for allcross-cluster communication to and from a Pod and the globalIp of a
 remote Service. Routing and iptable rules are configured to use the globalIp for ingress and egress. All address translations occur on the
 Gateway node.
 
@@ -55,9 +56,9 @@ It mainly consists of two key components: the IP Address Manager and Globalnet.
 The IP Address Manager (IPAM) component does the following:
 
 * Creates a pool of IP addresses based on the `GlobalCIDR` configured on cluster.
-* On creation of a Pod/Service, allocates a globalIp from the GlobalIp pool.
-* Annotates the Pod/Service with `submariner.io/globalIp=<global-ip>`.
-* On deletion of a Pod/Service, releases its globalIp back to the pool.
+* On creation of a Pod, or export of a Service, allocates a globalIp from the GlobalIp pool.
+* Annotates the Pod or exported Service with `submariner.io/globalIp=<global-ip>`.
+* On deletion of a Pod, Service or ServiceExport, releases its globalIp back to the pool.
 
 #### Globalnet
 

--- a/src/content/operations/known-issues/_index.en.md
+++ b/src/content/operations/known-issues/_index.en.md
@@ -19,6 +19,5 @@ Currently, Submariner does not support using [custom `ikeport` and `nattport`](.
 
 * Globalnet only supports Pod to remote Service connectivity using Global IPs. Pod to Pod connectivity is not supported at this time.
 * Globalnet is not compatible with Headless Services. Only ClusterIP Services are supported at this time.
-* Globalnet annotates every Service in a cluster at the moment, whether or not it was exported.
 * Currently, Globalnet is not supported with the OVN network plug-in.
 * The `subctl benchmark latency` command is not compatible with Globalnet deployments at this time.


### PR DESCRIPTION
Services running in a Globalnet deployment now require a ServiceExport
to be annotated with GlobalIP. Services that are not exported, will not
be reachable across clusters anymore.

Fixes #434 

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>