### PR TITLE
Use clean-clusters instead of cleanup

### DIFF
--- a/src/content/getting-started/quickstart/kind/_index.md
+++ b/src/content/getting-started/quickstart/kind/_index.md
@@ -149,5 +149,5 @@ curl nginx.default.svc.clusterset.local
 When you are done experimenting and you want to delete the clusters deployed in any of the previous steps, use the following command:
 
 ```bash
-make cleanup
+make clean-clusters
 ```


### PR DESCRIPTION
Following https://github.com/submariner-io/shipyard/pull/478

Signed-off-by: Stephen Kitt <skitt@redhat.com>