### PR TITLE
Add table of contents for empty sections

### DIFF
--- a/src/content/community/_index.en.md
+++ b/src/content/community/_index.en.md
@@ -3,3 +3,9 @@ title = "Community"
 weight = 30
 pre = "<b>3. </b>"
 +++
+
+* [Code of Conduct](code-of-conduct)
+* [Contributor Roles](contributor-roles)
+* [Getting Help](getting-help)
+* [Releases](releases)
+* [Roadmap](roadmap)

--- a/src/content/development/_index.en.md
+++ b/src/content/development/_index.en.md
@@ -4,3 +4,13 @@ date = 2020-02-19T20:24:34+01:00
 weight = 40
 pre = "<b>4. </b>"
 +++
+
+* [Building and Testing](building-testing)
+* [Code Review Guide](code-review)
+* [Contributing to the Website](website)
+  * [Docs Style Guide](website/style_guide.md)
+* [Release Process](release-process)
+* [Security Reporting](security)
+* [Working with Shipyard](shipyard)
+  * [Adding Shipyard to a Project](shipyard/first-time)
+  * [Advanced Features](shipyard/advanced)

--- a/src/content/getting-started/quickstart/_index.en.md
+++ b/src/content/getting-started/quickstart/_index.en.md
@@ -3,3 +3,12 @@ title = "Quickstart Guides"
 date = 2020-02-19T20:03:44+01:00
 weight = 20
 +++
+
+* [Sandbox Environment (kind)](kind)
+* [Managed Kubernetes](managed-kubernetes)
+  * [Google (GKE)](managed-kubernetes/gke)
+  * [Rancher](managed-kubernetes/rancher)
+* [OpenShift](openshift)
+  * [On AWS](openshift/aws)
+  * [On AWS with Globalnet](openshift/globalnet)
+  * [Hybrid vSphere and AWS](openshift/vsphere-aws)

--- a/src/content/getting-started/quickstart/managed-kubernetes/_index.en.md
+++ b/src/content/getting-started/quickstart/managed-kubernetes/_index.en.md
@@ -3,3 +3,6 @@ title = "Managed Kubernetes"
 date = 2020-02-19T20:03:44+01:00
 weight = 20
 +++
+
+* [Google (GKE)](gke)
+* [Rancher](rancher)

--- a/src/content/getting-started/quickstart/openshift/_index.md
+++ b/src/content/getting-started/quickstart/openshift/_index.md
@@ -3,3 +3,7 @@ date: 2020-02-21T13:36:18+01:00
 title: "OpenShift"
 weight: 30
 ---
+
+* [On AWS](aws)
+* [On AWS with Globalnet](globalnet)
+* [Hybrid vSphere and AWS](vsphere-aws)

--- a/src/content/operations/_index.en.md
+++ b/src/content/operations/_index.en.md
@@ -3,3 +3,13 @@ title = "Operations"
 weight = 20
 pre = "<b>2. </b>"
 +++
+
+* [Deployment](deployment)
+  * [subctl](deployment/subctl)
+  * [Helm](deployment/helm)
+  * [Calico CNI](deployment/calico)
+* [User Guide](usage)
+* [Monitoring](monitoring)
+* [Troubleshooting](troubleshooting)
+* [Known Issues](known-issues)
+* [Uninstalling Submariner](cleanup)


### PR DESCRIPTION
Add links to content contained in a section in the top-level section
index if the index is empty.

Closes: #431
Closes: #462
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>