### PR TITLE
Use a more specific regex when building all the stable branches

### DIFF
--- a/scripts/make-all-versions
+++ b/scripts/make-all-versions
@@ -4,7 +4,7 @@ set -ex
 
 git checkout devel
 make static
-RELEASES=$(git for-each-ref --format='%(refname)' refs/remotes/origin | awk -F/ '/release/ { print $NF }' )
+RELEASES=$(git for-each-ref --format='%(refname)' refs/remotes/origin | grep -E "origin/release-[0-9]+\.[0-9]+" | cut -d/ -f4)
 for release in $RELEASES; do
     VERSION=${release#release-}
     git checkout $release


### PR DESCRIPTION
The previous code was also picking up unexpected branches like:

remotes/origin/z_pr490/mkolesnik/release-update

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
