### PR TITLE
Fix broken CIDR Calculator URL

### DIFF
--- a/src/content/getting-started/quickstart/openshift/vsphere-aws/_index.md
+++ b/src/content/getting-started/quickstart/openshift/vsphere-aws/_index.md
@@ -62,7 +62,7 @@ Default output format [None]: text
 
 In this step you will deploy **cluster-b**, modifying the default IP CIDRs to avoid IP address conflicts with **cluster-a**. You can change
 the IP addresses block and prefix based on your requirements. For more information on IPv4 CIDR conversion,
-please check [this page](https://www.ipaddressguide.com/cidr).
+please check [this page](https://account.arin.net/public/cidrCalculator).
 
 In this example, we will use the following IP ranges:
 

--- a/src/resources/shared/openshift/create_clusters.md
+++ b/src/resources/shared/openshift/create_clusters.md
@@ -21,7 +21,7 @@ When the cluster deployment completes, directions for accessing your cluster, in
 
 In this step you will deploy **cluster-b**, modifying the default IP CIDRs to avoid IP address conflicts with **cluster-a**. You can change
 the IP addresses block and prefix based on your requirements. For more information on IPv4 CIDR conversion,
-please check [this page](https://www.ipaddressguide.com/cidr).
+please check [this page](https://account.arin.net/public/cidrCalculator).
 
 In this example, we will use the following IP ranges:
 


### PR DESCRIPTION
Use https://account.arin.net/public/cidrCalculator instead of https://www.ipaddressguide.com/cidr
Fixes: https://github.com/submariner-io/submariner-website/issues/501

Signed-off-by: nyechiel <nyechiel@redhat.com>