### PR TITLE
Fix `subctl-install` shortcode

### DIFF
--- a/src/content/getting-started/quickstart/k3s/_index.md
+++ b/src/content/getting-started/quickstart/k3s/_index.md
@@ -78,7 +78,7 @@ Next, copy kubeconfig.cluster-b to node-a.
 
 #### Install `subctl` on node-a
 
-{{< subctl-install >}}
+{{% subctl-install %}}
 
 #### Use cluster-a as the Broker
 

--- a/src/content/getting-started/quickstart/kind/_index.md
+++ b/src/content/getting-started/quickstart/kind/_index.md
@@ -78,7 +78,7 @@ For more information on interacting with kind, please refer to the [kind documen
 
 #### Install `subctl`
 
-{{< subctl-install >}}
+{{% subctl-install %}}
 
 #### Use cluster1 as Broker
 

--- a/src/content/getting-started/quickstart/managed-kubernetes/gke/_index.md
+++ b/src/content/getting-started/quickstart/managed-kubernetes/gke/_index.md
@@ -110,7 +110,7 @@ After this, the clusters are finally ready for Submariner!
 
 ## Deploy Submariner
 
-{{< subctl-install >}}
+{{% subctl-install %}}
 
 Deploy the [Broker](https://submariner.io/getting-started/architecture/broker/) on cluster-a.
 

--- a/src/content/getting-started/quickstart/managed-kubernetes/rancher/_index.md
+++ b/src/content/getting-started/quickstart/managed-kubernetes/rancher/_index.md
@@ -9,7 +9,7 @@ weight: 20
 
 ### Install subctl
 
-{{< subctl-install >}}
+{{% subctl-install %}}
 
 Obtain the kubeconfig files from the Rancher UI for each of your clusters, placing them in the respective kubeconfigs.
 

--- a/src/content/getting-started/quickstart/openshift/aws/_index.md
+++ b/src/content/getting-started/quickstart/openshift/aws/_index.md
@@ -40,7 +40,7 @@ customize the AWS instance type as shown below.
 
 ### Install `subctl`
 
-{{< subctl-install >}}
+{{% subctl-install %}}
 
 ### Install Submariner with Service Discovery
 

--- a/src/content/getting-started/quickstart/openshift/globalnet/_index.md
+++ b/src/content/getting-started/quickstart/openshift/globalnet/_index.md
@@ -76,7 +76,7 @@ customize the AWS instance type as shown below.
 
 ### Install `subctl`
 
-{{< subctl-install >}}
+{{% subctl-install %}}
 
 ### Install Submariner with Service Discovery and Globalnet
 

--- a/src/content/getting-started/quickstart/openshift/vsphere-aws/_index.md
+++ b/src/content/getting-started/quickstart/openshift/vsphere-aws/_index.md
@@ -130,7 +130,7 @@ export ENABLE_HA=true
 
 ### Submariner Installation
 
-{{< subctl-install >}}
+{{% subctl-install %}}
 
 #### Install Submariner with Service Discovery
 

--- a/src/content/operations/deployment/_index.en.md
+++ b/src/content/operations/deployment/_index.en.md
@@ -13,7 +13,7 @@ In addition to Operator and `subctl`, Submariner also provides [Helm Charts](hel
 
 ## Installing `subctl`
 
-{{< subctl-install >}}
+{{% subctl-install %}}
 
 ## Deployment of the Broker
 

--- a/src/content/operations/deployment/helm/_index.en.md
+++ b/src/content/operations/deployment/helm/_index.en.md
@@ -109,7 +109,7 @@ tests embedded in the `subctl` command line tool via the `subctl verify` command
 
 ### Install `subctl`
 
-{{< subctl-install >}}
+{{% subctl-install %}}
 
 ### Run the verification
 

--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -12,7 +12,7 @@ Operator](https://github.com/submariner-io/submariner-operator)
 
 ## Installation
 
-{{< subctl-install >}}
+{{% subctl-install %}}
 
 ### Installing specific versions
 

--- a/src/layouts/shortcodes/subctl-install.html
+++ b/src/layouts/shortcodes/subctl-install.html
@@ -1,24 +1,15 @@
 Download the subctl binary and make it available on your PATH.
 
-<div class="highlight">
-  <pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4">
-    <code class="language-bash" data-lang="bash">
-      curl -Ls https://get.submariner.io | bash
-      export PATH=$PATH:~/.local/bin
-      echo export PATH=\$PATH:~/.local/bin >> ~/.profile
-    </code>
-  </pre>
-</div>
+```bash
+curl -Ls https://get.submariner.io | bash
+export PATH=$PATH:~/.local/bin
+echo export PATH=\$PATH:~/.local/bin >> ~/.profile
+```
 
 If you have Go installed, you can use that instead:
 
-<div class="highlight">
-  <pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4">
-    <code class="language-bash" data-lang="bash">
-      go install github.com/submariner-io/submariner-operator/pkg/subctl
-    </code>
-  </pre>
-</div>
+```bash
+go install github.com/submariner-io/submariner-operator/pkg/subctl
+```
 
-(and ensure your <code>go/bin</code> directory is on
-your <code>PATH</code>).
+(and ensure your `go/bin` directory is on your `PATH`).


### PR DESCRIPTION
In Hugo, shortcodes can contain Markdown syntax if they're called with
`%`, so fixed the `subctl-install` one and the calls to it.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>