### PR TITLE
Refactor Getting Help docs

### DIFF
--- a/src/content/community/getting-help/_index.en.md
+++ b/src/content/community/getting-help/_index.en.md
@@ -7,22 +7,24 @@ weight = 30
 
 We would love to hear from you, how you are using Submariner, and what we can do to make it better.
 
-#### [GitHub Project](https://github.com/submariner-io)
+#### GitHub
 
-Check out the project and consider contributing. Pick up an issue to work on or propose an enhancement by reporting a new issue; once your
-code is ready to be reviewed, you can propose a pull request. You can find a good guide about the GitHub workflow
-[here](https://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project).
+Check out [Submariner's GitHub](https://github.com/submariner-io) and consider contributing. Pick up an issue to work on or propose an
+enhancement by reporting a new issue; once your code is ready to be reviewed, you can propose a pull request. You can find a good guide
+about the GitHub workflow [here](https://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project).
 
-#### [#submariner](https://kubernetes.slack.com/archives/C010RJV694M)
+#### Slack
 
-Share your ideas in the #submariner channel in Kubernetes' Slack. If you need it, you can [request an invite to Kubernetes Slack
-instance](https://slack.k8s.io/).
+Share your ideas in the [#submariner channel](https://kubernetes.slack.com/archives/C010RJV694M) in Kubernetes' Slack. If you need it, you
+can [request an invite to Kubernetes' Slack instance](https://slack.k8s.io/).
 
-#### [Community Calendar](https://calendar.google.com/calendar/r?cid=NHFuZGVoOGY0bzZ1ajlvZnBsczh1NWNlZ2tAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
+#### Community Calendar
 
-As a member of the Submariner Community, join any of our community meetings - no registration required. The weekly [Submariner Community
-Meeting](https://tinyurl.com/wfbx37q) (Tuesdays at 5:00pm CET) is a good place to start.
+Submariner's meetings are open to everyone. All meetings are documented on [Submariner's Community
+Calendar](https://calendar.google.com/calendar/r?cid=NHFuZGVoOGY0bzZ1ajlvZnBsczh1NWNlZ2tAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
+The weekly [Submariner Community Meeting](https://tinyurl.com/wfbx37q) (Tuesdays at 5:00pm CET) is a good place to start.
 
-#### [Mailing List](https://groups.google.com/forum/#!forum/submariner-dev)
+#### Mailing List
 
-Join the developer mailing list.
+Join the [submariner-dev](https://groups.google.com/forum/#!forum/submariner-dev) or
+[submariner-users](https://groups.google.com/forum/#!forum/submariner-users) mailing lists.


### PR DESCRIPTION
Extract links from headings so that links to headings don't have to
include the full URL of the link.

Add links back into paragraph bodies, improving where possible.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>