### PR TITLE
Add copyright notice to footer

### DIFF
--- a/src/layouts/partials/menu-footer.html
+++ b/src/layouts/partials/menu-footer.html
@@ -8,6 +8,7 @@
     <!-- Place this tag where you want the button to render. -->
     <a class="github-button" href="https://github.com/submariner-io/submariner/fork" data-icon="octicon-repo-forked" data-show-count="true" aria-label="Fork submariner-io/submariner on GitHub">Fork</a>
 
+    <p>Copyright © The Submariner Contributors</p>
 </center>
 <!-- Place this tag in your head or just before your close body tag. -->
 <script async defer src="https://buttons.github.io/buttons.js"></script>


### PR DESCRIPTION
Add Submariner's copyright notice to the left menu footer, so that it
shows on all content. This is a requirement for CNCF Sandbox onboarding.
    
Using a shorter option than we use in code to avoid wrapping.
    
https://github.com/cncf/foundation/blob/master/copyright-notices.md

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>