### PR TITLE
Document that Submariner is a CNCF sandbox project

### DIFF
--- a/src/content/_index.en.md
+++ b/src/content/_index.en.md
@@ -11,6 +11,8 @@ centers, and regions.
 
 Submariner is completely open source, and designed to be network plugin (CNI) agnostic.
 
+Submariner is a Cloud Native Computing Foundation sandbox project.
+
 ## What Submariner Provides
 
 * Cross-cluster L3 connectivity using encrypted VPN tunnels


### PR DESCRIPTION
Now that Submariner is a CNCF sandbox project, it is required by the
CNCF that we list this status prominently and use this wording.

https://github.com/cncf/foundation/blob/master/website-guidelines.md

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>