### PR TITLE
Document participates in security disclosures

### DIFF
--- a/src/content/development/security/reporting/_index.en.md
+++ b/src/content/development/security/reporting/_index.en.md
@@ -5,7 +5,9 @@ weight: 40
 
 Submariner welcomes and appreciates responsible disclosure of security vulnerabilities.
 
-If you know of a security issue with Submariner, please report it to submariner-security@googlegroups.com.
+If you know of a security issue with Submariner, please report it to submariner-security@googlegroups.com. [Submariner Project
+Owners](https://submariner.io/community/contributor-roles/#project-owner) receive security disclosures by default. They may share
+disclosures with others as required to make and propagate fixes.
 
 Submariner aspires to follow the [Kubernetes security reporting process](https://kubernetes.io/docs/reference/issues-security/security/),
 but is far too small of a project to implement those practices. Where applicable, Submariner will follow the principles of the Kubernetes


### PR DESCRIPTION
To better satisfy the Open Governance Checklist from opengovernance.dev,
clarify who receives security disclosures by default and who can
participate in security disclosures.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>