### PR TITLE
Add Linux Foundation trademark guidelines

### DIFF
--- a/src/layouts/partials/menu-footer.html
+++ b/src/layouts/partials/menu-footer.html
@@ -9,6 +9,7 @@
     <a class="github-button" href="https://github.com/submariner-io/submariner/fork" data-icon="octicon-repo-forked" data-show-count="true" aria-label="Fork submariner-io/submariner on GitHub">Fork</a>
 
     <p>Copyright © The Submariner Contributors</p>
+    <p>The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see <a href="https://www.linuxfoundation.org/trademark-usage/">Trademark Usage</a></p>
 </center>
 <!-- Place this tag in your head or just before your close body tag. -->
 <script async defer src="https://buttons.github.io/buttons.js"></script>


### PR DESCRIPTION
Per the CNCF Sandbox on-boarding requirements, include The Linux
Foundation Trademark Usage in the specified format.

https://github.com/cncf/foundation/blob/master/website-guidelines.md

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>