### PR TITLE
Add CNCF logo and Sandbox statement to menu footer

### DIFF
--- a/src/content/_index.en.md
+++ b/src/content/_index.en.md
@@ -11,8 +11,6 @@ centers, and regions.
 
 Submariner is completely open source, and designed to be network plugin (CNI) agnostic.
 
-Submariner is a Cloud Native Computing Foundation sandbox project.
-
 ## What Submariner Provides
 
 * Cross-cluster L3 connectivity using encrypted VPN tunnels

--- a/src/layouts/partials/menu-footer.html
+++ b/src/layouts/partials/menu-footer.html
@@ -9,7 +9,14 @@
     <a class="github-button" href="https://github.com/submariner-io/submariner/fork" data-icon="octicon-repo-forked" data-show-count="true" aria-label="Fork submariner-io/submariner on GitHub">Fork</a>
 
     <p>Copyright © The Submariner Contributors</p>
+
     <p>The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see <a href="https://www.linuxfoundation.org/trademark-usage/">Trademark Usage</a></p>
+
+    <p><a href="https://www.cncf.io">
+        <img class="cncf-logo" src="https://raw.githubusercontent.com/cncf/artwork/master/other/cncf/horizontal/white/cncf-white.svg" alt="Cloud Native Computing Foundation">
+    </a>
+    Submariner is a <a href="https://www.cncf.io">Cloud Native Computing Foundation</a> sandbox project.</p>
+
 </center>
 <!-- Place this tag in your head or just before your close body tag. -->
 <script async defer src="https://buttons.github.io/buttons.js"></script>


### PR DESCRIPTION
To better comply with the CNCF website guidelines as part of the CNCF
Sandbox on-boarding process, add the CNCF logo to the menu footer and
move the required membership statement to the footer from the home page.

https://github.com/cncf/foundation/blob/master/website-guidelines.md

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>