### PR TITLE
Reorder subctl installation section on OpenShift quickstarts

### DIFF
--- a/src/content/getting-started/quickstart/openshift/aws/_index.md
+++ b/src/content/getting-started/quickstart/openshift/aws/_index.md
@@ -20,14 +20,14 @@ please refer to the official [OpenShift documentation](https://docs.openshift.co
 {{< include "/resources/shared/openshift/setup_aws.md" >}}
 {{< include "/resources/shared/openshift/create_clusters.md" >}}
 
+### Install `subctl`
+
+{{% subctl-install %}}
+
 ### Prepare AWS Clusters for Submariner
 
 {{% cloud-prepare/intro %}}
 {{% cloud-prepare/aws clusters="cluster-a,cluster-b" %}}
-
-### Install `subctl`
-
-{{% subctl-install %}}
 
 ### Install Submariner with Service Discovery
 

--- a/src/content/getting-started/quickstart/openshift/globalnet/_index.md
+++ b/src/content/getting-started/quickstart/openshift/globalnet/_index.md
@@ -56,14 +56,14 @@ openshift-install create cluster --dir cluster-b
 When the cluster deployment completes, directions for accessing your cluster, including a link to its web console and credentials for the
 `kubeadmin` user, display in your terminal.
 
+### Install `subctl`
+
+{{% subctl-install %}}
+
 ### Prepare AWS Clusters for Submariner
 
 {{% cloud-prepare/intro %}}
 {{% cloud-prepare/aws clusters="cluster-a,cluster-b" %}}
-
-### Install `subctl`
-
-{{% subctl-install %}}
 
 ### Install Submariner with Service Discovery and Globalnet
 

--- a/src/content/getting-started/quickstart/openshift/vsphere-aws/_index.md
+++ b/src/content/getting-started/quickstart/openshift/vsphere-aws/_index.md
@@ -95,26 +95,26 @@ openshift-install create cluster --dir cluster-b
 When the cluster deployment completes, directions for accessing your cluster, including a link to its web console and credentials for the
 `kubeadmin` user, display in your terminal.
 
-#### Prepare AWS Cluster for Submariner
+### Install `subctl`
+
+{{% subctl-install %}}
+
+### Prepare AWS Cluster for Submariner
 
 {{% cloud-prepare/intro %}}
 {{% cloud-prepare/aws clusters="cluster-b" nattPort=4501 %}}
 
-### Submariner Installation
-
-{{% subctl-install %}}
-
-#### Install Submariner with Service Discovery
+### Install Submariner with Service Discovery
 
 To install Submariner with multi-cluster service discovery, follow the steps below:
 
-##### Use cluster-b (AWS) as Broker with Service Discovery enabled
+#### Use cluster-b (AWS) as Broker with Service Discovery enabled
 
 ```bash
 subctl deploy-broker --kubeconfig cluster-b/auth/kubeconfig
 ```
 
-##### Join cluster-b (AWS) and cluster-a (vSphere) to the Broker
+#### Join cluster-b (AWS) and cluster-a (vSphere) to the Broker
 
 ```bash
 subctl join --kubeconfig cluster-b/auth/kubeconfig broker-info.subm --ikeport 501 --nattport 4501


### PR DESCRIPTION
With the infrastructure preparation step done with `subctl cloud-prepare` now (and not with the `prep_for_subm` script), we need to instruct the user to install `subctl` before. This PR addresses this issue across all three OpenShift quickstart guides. 

Signed-off-by: nyechiel <nyechiel@redhat.com>