### PR TITLE
Update getting started deployment docs

### DIFF
--- a/src/content/getting-started/_index.en.md
+++ b/src/content/getting-started/_index.en.md
@@ -70,11 +70,8 @@ tested with the following network (CNI) Plugins:
 
 ## Deployment
 
-The available methods for deployment are:
+Submariner is deployed and managed using its Operator. [Submariner's Operator](https://github.com/submariner-io/submariner-operator) can be
+deployed using [subctl](../operations/deployment), [Helm](../operations/deployment/helm), or directly.
 
-* [subctl](../operations/deployment)
-* [Operator](https://github.com/submariner-io/submariner-operator)
-* [Helm](../operations/deployment/helm)
-
-`subctl` greatly simplifies the deployment of Submariner, and is therefore the recommended deployment
-method.
+`subctl` is the recommended deployment method because it has the most refined deployment user experience and additionally provides testing
+and bug-diagnosing capabilities.


### PR DESCRIPTION
Update the deployment summary in the getting started docs to reflect the
new reality that the Operator is always used, either by subctl, Helm, or
directly. Mention new subctl features as one reason it is recommended.

This section was part of the UX failure of a recent IBM Twitch stream.

https://www.youtube.com/watch?v=98rC2OOW20w

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>