### PR TITLE
Add licensing information

### DIFF
--- a/src/content/development/_index.en.md
+++ b/src/content/development/_index.en.md
@@ -9,6 +9,7 @@ pre = "<b>4. </b>"
 * [Code Review Guide](code-review)
 * [Contributing to the Website](website)
   * [Docs Style Guide](website/style-guide)
+* [Licenses](licenses)
 * [Release Process](release-process)
 * [Security](security)
   * [Security Reporting](security/reporting)

--- a/src/content/development/licenses/_index.en.md
+++ b/src/content/development/licenses/_index.en.md
@@ -1,0 +1,40 @@
+---
+title: "Licenses"
+date: 2021-06-09T13:52:26+02:00
+weight: 35
+---
+
+Content contributed to the Submariner project must be made available under one of two licenses.
+
+## Contributions to projects other than the website
+
+These must be made available under the [Apache License, version 2.0](https://opensource.org/licenses/Apache-2.0).
+Go files must start with the following header:
+
+```go
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+```
+
+This is enforced by our CI.
+
+## Contributions to the website
+
+Contributions to the website must be made available under the
+[Creative Commons Attribution 4.0 International license](https://creativecommons.org/licenses/by/4.0/)
+(CC BY 4.0).


### PR DESCRIPTION
This documents the licenses we expect, and the exact header which our
CI checks for.

Signed-off-by: Stephen Kitt <skitt@redhat.com>