### PR TITLE
Switch to the CODEOWNERS generator

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
-* @mangelajo @tpantelis @Oats87 @skitt
-Makefile @mkolesnik
-scripts/* @mkolesnik
-src/content/development/* @mkolesnik
+# Auto-generated, do not edit; see CODEOWNERS.in
+* @mangelajo @Oats87 @skitt @tpantelis
+/scripts/ @mangelajo @mkolesnik @Oats87 @skitt @tpantelis
+/src/content/development/ @mangelajo @mkolesnik @Oats87 @skitt @tpantelis
+Makefile @mangelajo @mkolesnik @Oats87 @skitt @tpantelis

--- a/CODEOWNERS.in
+++ b/CODEOWNERS.in
@@ -1,0 +1,5 @@
+@mangelajo *
+@Oats87 *
+@skitt *
+@tpantelis *
+@mkolesnik Makefile /scripts/ /src/content/development/

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ static: hugo
 static-all: hugo
 	./scripts/make-all-versions # we use a script because we expect that changes could happen on makefiles
 
+CODEOWNERS: CODEOWNERS.in
+	$(CURDIR)/scripts/gen-codeowners
 
 .DEFAULT_GOAL := static 
 

--- a/scripts/gen-codeowners
+++ b/scripts/gen-codeowners
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+from fnmatch import fnmatch
+
+with open('CODEOWNERS.in', 'r') as ins, open('CODEOWNERS', 'w') as out:
+    owners_by_path = {}
+    for line in ins:
+        comps = line.split()
+        if len(comps) > 1:
+            for path in comps[1:]:
+                owners_by_path.setdefault(path, set()).add(comps[0])
+    print('# Auto-generated, do not edit; see CODEOWNERS.in', file = out)
+    for path in sorted(owners_by_path, key = str.lower):
+        owners = owners_by_path[path]
+        for extra_path in owners_by_path.keys():
+            if extra_path != path and fnmatch(path, extra_path):
+                owners |= owners_by_path[extra_path]
+        print('{0} {1}'.format(path, ' '.join(sorted(owners, key = str.lower))), file = out)


### PR DESCRIPTION
This ensures that the various paths are defined correctly, repeating
owners as necessary. To avoid a dependency on Shipyard, the
gen-codeowners script is copied wholesale.

Signed-off-by: Stephen Kitt <skitt@redhat.com>