### PR TITLE
Document usage of kubecontexts in subctl benchmark

### DIFF
--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -252,7 +252,6 @@ When running `benchmark latency`, two types of tests will be executed:
 |:------------------------------------|:----------------------------------------------------------------------------|
 | `--intra-cluster`                   | Performs the benchmark test within a single cluster between Pods from a Non-Gateway node to a Gateway node
 | `--verbose`                         | Produce verbose logs during benchmark tests
-| `--kubeconfig` `<string>`           | Absolute path(s) to the kubeconfig file(s)
 <!-- markdownlint-enable line-length -->
 
 ### `diagnose`

--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -226,7 +226,7 @@ that this verification is disruptive.
 
 #### `benchmark throughput`
 
-`subctl benchmark throughput <kubeconfig1> [<kubeconfig2>] [flags]`
+`subctl benchmark throughput --kubecontexts <context1>[,<context2>] [flags]`
 
 The `benchmark throughput` command runs a throughput benchmark test between two specified clusters or within a single cluster.
 It deploys a Pod to run the [iperf](https://iperf.fr/) tool and logs the output to the console.
@@ -237,7 +237,7 @@ When running `benchmark throughput`, two types of tests will be executed:
 
 #### `benchmark latency`
 
-`subctl benchmark latency <kubeconfig1> [<kubeconfig2>] [flags]`
+`subctl benchmark latency --kubecontexts <context1>[,<context2>] [flags]`
 
 The `benchmark latency` command runs a latency benchmark test between two specified clusters or within a single cluster.
 It deploys a Pod to run the [netperf](https://hewlettpackard.github.io/netperf/doc/netperf.html) tool and logs the output to the console.
@@ -252,6 +252,7 @@ When running `benchmark latency`, two types of tests will be executed:
 |:------------------------------------|:----------------------------------------------------------------------------|
 | `--intra-cluster`                   | Performs the benchmark test within a single cluster between Pods from a Non-Gateway node to a Gateway node
 | `--verbose`                         | Produce verbose logs during benchmark tests
+| `--kubeconfig` `<string>`           | Absolute path(s) to the kubeconfig file(s)
 <!-- markdownlint-enable line-length -->
 
 ### `diagnose`


### PR DESCRIPTION
Signed-off-by: Maayan Friedman <maafried@redhat.com>