### PR TITLE
When checking links, ignore GHA links

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -7,6 +7,9 @@
       "pattern": "^https://github.com/pulls"
     },
     {
+      "pattern": "^https://github.com/\\S+/\\S+/actions"
+    },
+    {
       "pattern": "^http://localhost:"
     },
     {


### PR DESCRIPTION
Links such as
https://github.com/submariner-io/releases/actions?query=workflow%3APeriodic
are only accessible when authenticated.

This was flagged by the periodic link checker (see
.github/ISSUE_TEMPLATE/broken-link.md).

Fixes: #181
Signed-off-by: Stephen Kitt <skitt@redhat.com>