### PR TITLE
Don't run periodic PR dependency checks on forks

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   check:
     name: Check Dependencies
+    if: github.repository_owner == 'submariner-io'
     runs-on: ubuntu-latest
     steps:
       - uses: z0al/dependent-issues@v1


### PR DESCRIPTION
As we do with the Flake Finder and other periodic jobs, skip the checks
for PR dependencies on forks.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>