### PR TITLE
Revert to a r/w version of dependent-issues

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository_owner == 'submariner-io'
     runs-on: ubuntu-latest
     steps:
-      - uses: z0al/dependent-issues@v1
+      - uses: z0al/dependent-issues@1208b4dd978973b14de5b0b227a2871dbbf34ffb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Current versions of dependent-issues skip PRs opened by dependabot,
because GitHub now only provides readonly tokens for pull_request
actions triggered on dependabot PRs. However dependent-issues relies
on a pull_request_target event anyway, so it should still have a
read-write token.

This means that the “Dependent Issues” check stays in “Expected”
status; if we want to keep it as “Required” then we need some
workaround to be able to merge dependabot PRs.

This reverts to the last commit of dependent-issues before the change
to disable the check on dependabot PRs.

Signed-off-by: Stephen Kitt <skitt@redhat.com>