### PR TITLE
Set yamllint strict flag correctly, fix warnings

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -17,7 +17,7 @@ on:
       - reopened
       - synchronize
   schedule:
-    - cron: '0 0/6 * * *' # every 6 hours
+    - cron: '0 0/6 * * *'  # every 6 hours
 
 jobs:
   check:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -62,3 +62,4 @@ jobs:
         with:
           file_or_dir: .
           config_file: .yamllint.yml
+          strict: true

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -10,5 +10,3 @@ rules:
 
 ignore: |
   /src/themes
-
-strict: true


### PR DESCRIPTION
Setting yamllint to exit non-zero on warnings doesn't work from the
.yamllint config file.

Set the --strict flag at CLI invocation, which in this case is handled
by the GHA and must be configured there.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>