### PR TITLE
Quickstart for LB mode on GCP Cloud

### DIFF
--- a/src/content/getting-started/quickstart/openshift/gcp-lb/_index.md
+++ b/src/content/getting-started/quickstart/openshift/gcp-lb/_index.md
@@ -1,11 +1,11 @@
 ---
 date: 2020-02-21T13:36:18+01:00
-title: "On AWS (LoadBalancer mode)"
+title: "On GCP (LoadBalancer mode)"
 weight: 20
 ---
 
 This quickstart guide covers the necessary steps to deploy two OpenShift Container Platform (OCP)
-clusters on AWS leveraging a cloud network load balancer service in front of the Submariner gateways.
+clusters on GCP leveraging a cloud network load balancer service in front of the Submariner gateways.
 
 The main benefit of this mode is that there is no need to dedicate specialized nodes with a public IP
 address to act as gateways. The administrator only needs to manually label any existing
@@ -17,24 +17,24 @@ Please note that this mode is still experimental and may need more testing. For 
 measured the impact on HA failover times.
 {{% /notice %}}
 
-{{< include "/resources/shared/openshift/setup_openshift.md" >}}
+{{< include "/resources/shared/openshift/setup_openshift_gcp.md" >}}
 
 {{% notice info %}}
 Please ensure that the tools you downloaded above are compatible with your OpenShift Container Platform version. For more information,
 please refer to the official [OpenShift documentation](https://docs.openshift.com/container-platform/).
 {{% /notice %}}
 
-{{< include "/resources/shared/openshift/setup_aws.md" >}}
+{{< include "/resources/shared/openshift/setup_gcp.md" >}}
 {{< include "/resources/shared/openshift/create_clusters.md" >}}
 
 ### Install `subctl`
 
 {{% subctl-install %}}
 
-### Prepare AWS Clusters for Submariner
+### Prepare GCP Clusters for Submariner
 
 {{% cloud-prepare/intro %}}
-{{% cloud-prepare/aws-lb clusters="cluster-a,cluster-b" %}}
+{{% cloud-prepare/gcp-lb clusters="cluster-a,cluster-b" %}}
 
 ### Install Submariner with Service Discovery
 

--- a/src/layouts/shortcodes/cloud-prepare/gcp-lb.md
+++ b/src/layouts/shortcodes/cloud-prepare/gcp-lb.md
@@ -1,0 +1,10 @@
+{{- $clusters := $.Get "clusters" }}
+{{- range $cluster := split $clusters "," }}
+Run the command for **{{ $cluster }}**:
+
+```bash
+export KUBECONFIG={{ $cluster }}/auth/kubeconfig
+subctl cloud prepare gcp --ocp-metadata {{ $cluster }}/metadata.json
+```
+
+{{- end }}

--- a/src/layouts/shortcodes/cloud-prepare/intro.md
+++ b/src/layouts/shortcodes/cloud-prepare/intro.md
@@ -4,5 +4,5 @@ retrieve metrics from the Gateway nodes.
 Additionally, the default OpenShift deployment does not allow assigning an elastic public IP to existing worker nodes, which may be
 necessary on one end of the tunnel connection.
 
-`subctl cloud prepare` is a command designed to update your OpenShift installer provisioned AWS infrastructure for Submariner deployments,
+`subctl cloud prepare` is a command designed to update your OpenShift installer provisioned infrastructure for Submariner deployments,
 handling the requirements specified above.

--- a/src/resources/shared/openshift/setup_gcp.md
+++ b/src/resources/shared/openshift/setup_gcp.md
@@ -1,0 +1,6 @@
+### Setup Your GCP Profile
+
+Configure the GCP Credentials like project_id, private_key etc in ~/.gcp/osServiceAccount.json file.
+Please refer to the official
+[doc](https://docs.openshift.com/container-platform/4.8/installing/installing_gcp/installing-gcp-account.html#installing-gcp-account)
+for detailed instructions

--- a/src/resources/shared/openshift/setup_openshift_gcp.md
+++ b/src/resources/shared/openshift/setup_openshift_gcp.md
@@ -1,0 +1,7 @@
+### Prerequisites
+
+Before we begin, the following tools need to be downloaded and added to your `$PATH`:
+
+1. **OpenShift installer**, **pull secret**, and **command line interface**. All can be downloaded from
+   [here](https://cloud.redhat.com/openshift/install/aws/installer-provisioned).
+2. **GCP CLI** which can be downloaded from [here](https://cloud.google.com/sdk/gcloud).


### PR DESCRIPTION
Submariner supports loadbalancer mode for gateway node, but
currently this implementation on AWS is having some issues.
The same functionality on GCP works fine. This PR updates
the quick start guide to GCP cloud.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>