### PR TITLE
Rename job so it won't shard on stable branches

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
 
 jobs:
-  target_devel:
-    name: PR targets devel
+  target_branch:
+    name: PR targets branch
     runs-on: ubuntu-latest
     steps:
       - name: Check that the PR targets devel


### PR DESCRIPTION
Right now auto release logic updates `devel` to the stable branch name
when creating stable branches. This leads to this job "sharding" into
multiple jobs, and messes up branch protections.

To keep things simple, the main job name will remain the same so that
there's no "PR targets X" and "PR targets Y" jobs, just the one "PR
targets branch" job

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>