### PR TITLE
Doc that diag inter-cluster requires two configs

### DIFF
--- a/src/content/operations/troubleshooting/_index.en.md
+++ b/src/content/operations/troubleshooting/_index.en.md
@@ -35,7 +35,7 @@ Get an idea of what's failing:
 
 ```shell
 subctl diagnose all
-subctl diagnose firewall inter-cluster
+subctl diagnose firewall inter-cluster <kubeconfig0 path> <kubeconfig1 path>
 ```
 
 Collect details about an issue you'd like help with:


### PR DESCRIPTION
Document that subctl diagnose firewall inter-cluster requires two
KUBECONFIG arguments.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>