### PR TITLE
Fix broken load balancer link

### DIFF
--- a/src/content/operations/known-issues/_index.en.md
+++ b/src/content/operations/known-issues/_index.en.md
@@ -12,7 +12,7 @@ weight = 40
 [GKE Quickstart Guide](../../getting-started/quickstart/managed-kubernetes/gke/#final-workaround-for-kubedns) for more information.
 * Clusters deployed with the Calico network plug-in require further configuration to be compatible with Submariner. Please refer to the
 [Calico-specific deployment instructions](../deployment/calico/).
-* The [Gateway load balancer support](../../getting-started/quickstart/openshift/aws-lb/) is still experimental and needs more testing.
+* The [Gateway load balancer support](../../getting-started/quickstart/openshift/gcp-lb/) is still experimental and needs more testing.
 * Submariner Gateway metrics `submariner_gateway_rx_bytes` and `submariner_gateway_tx_bytes` will not be collected when using the
 VXLAN cable driver.
 


### PR DESCRIPTION
```
FILE: src/content/operations/known-issues/_index.en.md
[✖] ../../getting-started/quickstart/openshift/aws-lb/

3 links checked.

ERROR: 1 dead links found!
[✖] ../../getting-started/quickstart/openshift/aws-lb/ → Status: 400
```

The `aws-lb` section was migrated to `gcp_lb`.
