### PR TITLE
Remove known issue Globalnet Headless Services

### DIFF
--- a/src/content/operations/known-issues/_index.en.md
+++ b/src/content/operations/known-issues/_index.en.md
@@ -19,6 +19,5 @@ VXLAN cable driver.
 ## Globalnet
 
 * Globalnet only supports Pod to remote Service connectivity using Global IPs. Pod to Pod connectivity is not supported at this time.
-* Globalnet is not compatible with Headless Services. Only ClusterIP Services are supported at this time.
 * Currently, Globalnet is not supported with the OVN network plug-in.
 * The `subctl benchmark latency` command is not compatible with Globalnet deployments at this time.


### PR DESCRIPTION
Submariner supports this as of 0.10.1, so remove it from the list of
known issues.

> Globalnet now supports headless Services.

https://submariner.io/community/releases/#v0101

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>