### PR TITLE
Fix Go-based subctl install docs

### DIFF
--- a/src/layouts/shortcodes/subctl-install.html
+++ b/src/layouts/shortcodes/subctl-install.html
@@ -6,9 +6,10 @@ export PATH=$PATH:~/.local/bin
 echo export PATH=\$PATH:~/.local/bin >> ~/.profile
 ```
 
-If you have Go installed, you can use that instead:
+If you have Go and the [source code](https://github.com/submariner-io/submariner-operator), you can build and install subctl instead:
 
 ```bash
+cd go/src/submariner-io/submariner-operator
 go install github.com/submariner-io/submariner-operator/pkg/subctl
 ```
 


### PR DESCRIPTION
Because we have `replace` statements in `submariner-operator/go.mod` to
pin the K8s version, when run from outside of the submariner-operator
repo `go install` declines to build `subctl` with:

```
The go.mod file for the module providing named packages contains one or
more replace directives. It must not contain directives that would cause
it to be interpreted differently than if it were the main module.
```

This issue is described upstream here:

https://github.com/golang/go/issues/44840#issuecomment-967294447

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>