### PR TITLE
Remove outdated note about Globalnet and headless services

### DIFF
--- a/src/content/getting-started/quickstart/kind/_index.md
+++ b/src/content/getting-started/quickstart/kind/_index.md
@@ -137,10 +137,6 @@ subctl export service --kubeconfig output/kubeconfigs/kind-config-cluster2 --nam
 
 ##### Deploy Headless Service
 
-{{% notice note %}}
-Headless Services can only be exported on non-Globalnet deployments.
-{{% /notice %}}
-
 ```bash
 kubectl --kubeconfig output/kubeconfigs/kind-config-cluster2 create deployment nginx --image=nginx
 kubectl --kubeconfig output/kubeconfigs/kind-config-cluster2 expose deployment nginx --port=80 --cluster-ip=None


### PR DESCRIPTION
https://submariner.io/getting-started/quickstart/kind/ currently has a note that says "Headless Services can only be exported on non-Globalnet deployments" which is no longer true with the recent implementation of Globalnet (Submariner 0.10 and above) as described [here](https://github.com/submariner-io/enhancements/pull/22).


Signed-off-by: nyechiel <nyechiel@redhat.com>