### PR TITLE
Remove outdated Globalnet known issue

### DIFF
--- a/src/content/operations/known-issues/_index.en.md
+++ b/src/content/operations/known-issues/_index.en.md
@@ -18,6 +18,5 @@ VXLAN cable driver.
 
 ## Globalnet
 
-* Globalnet only supports Pod to remote Service connectivity using Global IPs. Pod to Pod connectivity is not supported at this time.
 * Currently, Globalnet is not supported with the OVN network plug-in.
 * The `subctl benchmark latency` command is not compatible with Globalnet deployments at this time.


### PR DESCRIPTION
https://submariner.io/operations/known-issues/ currently says "Globalnet only supports Pod to remote Service connectivity using Global IPs. Pod to Pod connectivity is not supported at this time" which is no longer true with the [recent implementation of Globalnet](https://github.com/submariner-io/enhancements/pull/22). Further information about Globalnet and Headless services is already available in the [Globalnet Architecture](https://submariner.io/getting-started/architecture/globalnet/) section.

Signed-off-by: nyechiel <nyechiel@redhat.com>