### PR TITLE
Add External Network guide to the quickstart index

### DIFF
--- a/src/content/getting-started/quickstart/_index.en.md
+++ b/src/content/getting-started/quickstart/_index.en.md
@@ -13,3 +13,4 @@ weight = 20
   * [On AWS](openshift/aws)
   * [On AWS with Globalnet](openshift/globalnet)
   * [Hybrid vSphere and AWS](openshift/vsphere-aws)
+* [External Network (Experimental)](external)


### PR DESCRIPTION
Now that https://github.com/submariner-io/submariner-website/pull/573 is merged, reference it from the Quickstart Guides index page.

Signed-off-by: nyechiel <nyechiel@redhat.com>