### PR TITLE
Missing dot on subctl guide

### DIFF
--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -4,7 +4,7 @@ weight: 10
 ---
 
 The `subctl` command-line utility simplifies the deployment and maintenance of Submariner by automating interactions with the [Submariner
-Operator](https://github.com/submariner-io/submariner-operator)
+Operator](https://github.com/submariner-io/submariner-operator).
 
 ## Synopsis
 


### PR DESCRIPTION
Whenever I open the [subctl guide](https://submariner.io/operations/deployment/subctl/), I stumble upon the missing dot at the end of the first sentence and say that I will fix it some day. This day has come.

Signed-off-by: nyechiel <nyechiel@redhat.com>