### PR TITLE
Verify: remove --generator=run-pod/v1 obsolete flag

### DIFF
--- a/src/content/getting-started/quickstart/k3s/_index.md
+++ b/src/content/getting-started/quickstart/k3s/_index.md
@@ -131,7 +131,6 @@ subctl export service --kubeconfig kubeconfig.cluster-b --namespace default ngin
 Run `nettest` from `cluster-a` to access the `nginx` service:
 
 ```bash
-kubectl --kubeconfig kubeconfig.cluster-a -n default  run --generator=run-pod/v1 \
-tmp-shell --rm -i --tty --image quay.io/submariner/nettest -- /bin/bash
+kubectl --kubeconfig kubeconfig.cluster-a -n default run tmp-shell --rm -i --tty --image quay.io/submariner/nettest -- /bin/bash
 curl nginx.default.svc.clusterset.local
 ```

--- a/src/content/getting-started/quickstart/kind/_index.md
+++ b/src/content/getting-started/quickstart/kind/_index.md
@@ -148,8 +148,8 @@ subctl export service --kubeconfig output/kubeconfigs/kind-config-cluster2 --nam
 Run `nettest` from `cluster1` to access the `nginx` service:
 
 ```bash
-kubectl --kubeconfig output/kubeconfigs/kind-config-cluster1 -n default  run --generator=run-pod/v1 \
-tmp-shell --rm -i --tty --image quay.io/submariner/nettest -- /bin/bash
+kubectl --kubeconfig output/kubeconfigs/kind-config-cluster1 -n default run tmp-shell --rm -i --tty --image quay.io/submariner/nettest \
+-- /bin/bash
 curl nginx.default.svc.clusterset.local
 ```
 

--- a/src/content/operations/usage/_index.en.md
+++ b/src/content/operations/usage/_index.en.md
@@ -366,8 +366,7 @@ Next, run a test Pod on **cluster2** and try to access the `nginx` Service from 
 $ kubectl create namespace nginx-test
 namespace/nginx-test created
 
-$ kubectl -n nginx-test  run --generator=run-pod/v1 \
-tmp-shell --rm -i --tty --image quay.io/submariner/nettest -- /bin/bash
+$ kubectl run -n nginx-test tmp-shell --rm -i --tty --image quay.io/submariner/nettest -- /bin/bash
 ```
 
 ```bash
@@ -552,8 +551,7 @@ Events:                    <none>
 Run a test Pod on **cluster2** and try to access the `nginx` Service from within the Pod:
 
 ```bash
-$ kubectl -n nginx-test  run --generator=run-pod/v1 \
-tmp-shell --rm -i --tty --image quay.io/submariner/nettest -- /bin/bash
+kubectl run -n nginx-test tmp-shell --rm -i --tty --image quay.io/submariner/nettest -- /bin/bash
 ```
 
 ```bash
@@ -843,8 +841,7 @@ nginx-ss-nginx-test-cluster3   Headless                         5m48s
 Next, run a test Pod on **cluster2** and try to access the `nginx-ss` Service from within the Pod:
 
 ```bash
-kubectl -n nginx-test  run --generator=run-pod/v1 \
-tmp-shell --rm -i --tty --image quay.io/submariner/nettest -- /bin/bash
+kubectl run -n nginx-test tmp-shell --rm -i --tty --image quay.io/submariner/nettest -- /bin/bash
 ```
 <!-- markdownlint-disable no-hard-tabs -->
 ```bash

--- a/src/resources/shared/verify_with_discovery.md
+++ b/src/resources/shared/verify_with_discovery.md
@@ -26,7 +26,7 @@ Run `nettest` from `cluster-a` to access the `nginx` service:
 
 ```bash
 export KUBECONFIG=cluster-a/auth/kubeconfig
-kubectl -n default  run --generator=run-pod/v1 tmp-shell --rm -i --tty --image quay.io/submariner/nettest -- /bin/bash
+kubectl -n default run tmp-shell --rm -i --tty --image quay.io/submariner/nettest -- /bin/bash
 curl nginx.default.svc.clusterset.local:8080
 ```
 


### PR DESCRIPTION
Closes https://github.com/submariner-io/submariner-website/issues/617

Signed-off-by: nyechiel <nyechiel@redhat.com>