### PR TITLE
Modify the `make backport` command to build locally

### DIFF
--- a/src/content/development/backports/_index.en.md
+++ b/src/content/development/backports/_index.en.md
@@ -28,7 +28,7 @@ This ensures that commit identifiers will remain stable during the backport proc
 
 Backporting a pull request (PR) is automated by running:
 
-`make backport release=<release-branch> pr=<PR to cherry-pick>`
+`make LOCAL_BUILD=1 backport release=<release-branch> pr=<PR to cherry-pick>`
 
 The `make` target runs a script,
 [backport.sh](https://github.com/submariner-io/shipyard/blob/devel/scripts/shared/backport.sh), originally developed by the [Kubernetes community](https://github.com/kubernetes/kubernetes/blob/master/hack/cherry_pick_pull.sh).


### PR DESCRIPTION
following modifications in
https://github.com/submariner-io/shipyard/pull/692

Signed-Off-By: Janki Chhatbar <jchhatba@redhat.com>