### PR TITLE
Add NET_ADMIN capabilities to the dnsmasq deployment

### DIFF
--- a/src/content/getting-started/quickstart/external/_index.md
+++ b/src/content/getting-started/quickstart/external/_index.md
@@ -140,6 +140,9 @@ spec:
         ports:
         - containerPort: 53
         command: [ "/bin/sh", "-c", "microdnf install -y dnsmasq; ln -s /upstreamservers /etc/dnsmasq.d/upstreamservers; dnsmasq -k" ]
+        securityContext:
+          capabilities:
+            add: ["NET_ADMIN"]
         volumeMounts:
         - name: upstreamservers
           mountPath: /upstreamservers


### PR DESCRIPTION
- this commit resolves an issue of dnsmasq not starting

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>