### PR TITLE
Update "Deploy Automatically" for 'make deploy'

### DIFF
--- a/src/content/development/shipyard/advanced/_index.en.md
+++ b/src/content/development/shipyard/advanced/_index.en.md
@@ -102,9 +102,10 @@ name). These flags affect how Submariner is deployed on the clusters.
 Since `deploy` relies on `clusters` then effectively you could also specify `CLUSTERS_ARGS` to control the cluster deployment (provided the
 cluster hasn't been deployed yet).
 
-Flags of note:
+Flags of note (see the flags defined in [deploy.sh](https://github.com/submariner-io/shipyard/blob/devel/scripts/shared/deploy.sh)
+for the full list):
 
-* **deploytool:** Specifies the deployment tool to use: `operator` (default) or `helm`.
+* **deploytool:** Specifies the deployment tool to use: `operator` (default), `helm`, `bundle` or `ocm`.
 
   ```bash
   make deploy DEPLOY_ARGS='--deploytool operator'
@@ -113,7 +114,7 @@ Flags of note:
 * **deploytool_broker_args:** Any extra arguments to pass to the deploy tool when deploying the broker.
 
   ```bash
-  make deploy DEPLOY_ARGS='--deploytool operator --deploytool_broker_args "--service-discovery"'
+  make deploy DEPLOY_ARGS='--deploytool operator --deploytool_broker_args "--components service-discovery,connectivity"'
   ```
 
 * **deploytool_submariner_args:** Any extra arguments to pass to the deploy tool when deploying Submariner.
@@ -122,10 +123,21 @@ Flags of note:
   make deploy DEPLOY_ARGS='--deploytool operator --deploytool_submariner_args "--cable-driver wireguard"'
   ```
 
+As shown above, arguments can be passed directly to the Broker and Submariner.
+The deploy script also has flags that group common options together for easier user experience.
+For example, the [`service_discovery` flag in `deploy.sh`](https://github.com/submariner-io/shipyard/blob/devel/scripts/shared/deploy.sh)
+will handle the `--components service-discovery,connectivity` flags mentioned above. Other examples:
+
 * **globalnet:** When set, deploys Submariner with the globalnet controller, and assigns a unique Global CIDR to each cluster.
 
   ```bash
   make deploy DEPLOY_ARGS='--globalnet'
+  ```
+
+* **cable_driver:** Override the default cable driver to configure the tunneling method for connections between clusters.
+
+  ```bash
+  make deploy DEPLOY_ARGS='--cable_driver wireguard'
   ```
 
 #### Example: Passing Deployment Variables
@@ -134,7 +146,7 @@ As an example, in order to deploy with Lighthouse and support both Operator and 
 
 ```Makefile
 ifeq ($(deploytool),operator)
-DEPLOY_ARGS += --deploytool operator --deploytool_broker_args '--service-discovery'
+DEPLOY_ARGS += --deploytool operator --deploytool_broker_args '--components service-discovery,connectivity'
 else
 DEPLOY_ARGS += --deploytool helm --deploytool_broker_args '--set submariner.serviceDiscovery=true' --deploytool_submariner_args '--set submariner.serviceDiscovery=true,lighthouse.image.repository=localhost:5000/lighthouse-agent,serviceAccounts.lighthouse.create=true'
 endif

--- a/src/content/getting-started/quickstart/kind/_index.md
+++ b/src/content/getting-started/quickstart/kind/_index.md
@@ -18,16 +18,21 @@ Submariner provides automation to deploy clusters using kind and connect them us
 
 ### Deploy Automatically
 
-To create kind clusters and deploy Submariner, run:
+To create kind clusters and deploy Submariner with service discovery enabled, run:
 
 ```bash
 git clone https://github.com/submariner-io/submariner-operator
 cd submariner-operator
-make deploy
+make deploy using=lighthouse
 ```
 
 By default, the automation configuration in the submariner-io/submariner-operator repository deploys two clusters, with cluster1 configured as
 the Broker. See the [settings](https://github.com/submariner-io/submariner-operator/blob/devel/.shipyard.e2e.yml) file for details.
+
+Once you become familiar with Submariner's basics, you may want to visit the
+[Building and Testing page](../../../development/building-testing/) to learn more about customizing your Submariner development deployment.
+To understand how Submariner's development deployment infrastructure works under the hood, see
+[Submariner Deployment Customization in the Shipyard Advanced Options](../../../development/shipyard/advanced/).
 
 ### Deploy Manually
 


### PR DESCRIPTION
The "Deploy Automatically" directions use 'make deploy' then give an
example on how to test the deployment. By default, lighthouse was not
being deployed, so test example was failing. Update to
'make deploy using=lighthouse'.

In debugging this, took a while to stumble on how to customize a Submariner
deployment. So also adding a shortcut to the existing documentation on
customizing to this section in the document. The customization example
failed with syntax error, so updating this section as well to the current
syntax.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>