### PR TITLE
Link to demo of SubM for DR with ACM

### DIFF
--- a/src/content/other-resources/_index.en.md
+++ b/src/content/other-resources/_index.en.md
@@ -22,6 +22,8 @@ There are multiple presentations and demo recordings about Submariner available 
 
 ## Demo Recordings
 
+* [Automated Disaster Recovery failover and failback with Red Hat OpenShift (01/2021)](https://www.youtube.com/watch?v=OPKVKPfJrRA), or with
+  more discussion on [Ask an OpenShift Admin (Ep 55): Disaster recovery with ODF and ACM (01/2021)](https://youtu.be/Tlmuvkq_OPo?t=1177)
 * [Submariner in 60s (05/2020)](https://www.youtube.com/watch?v=pQgUWiGtKqM)
 * [Connecting hybrid Kubernetes clusters using Submariner (03/2020)](https://www.youtube.com/watch?v=fMhZRNn0fxQ)
 * [Cross-cluster service discovery in Submariner using Lighthouse (03/2020)](https://www.youtube.com/watch?v=tXsemQPNhyQ)


### PR DESCRIPTION
Link to a demo of Submariner being used for disaster recovery as a part
of Red Hat's Advance Cluster Management. This is a useful, recent
reference for a way Submariner can be used.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>