### PR TITLE
Add Help Wanted docs, GH tag query

### DIFF
--- a/src/content/development/_index.en.md
+++ b/src/content/development/_index.en.md
@@ -20,6 +20,13 @@ pre = "<b>4. </b>"
   * [Adding Shipyard to a Project](shipyard/first-time)
   * [Advanced Features](shipyard/advanced)
 
+### Help Wanted
+
+If you'd like to get involved and haven't already found something to work on, check the [GitHub Issues tagged "help
+wanted"](https://github.com/pulls?q=is%3Aopen+user%3Asubmariner-io+label%3A%22help+wanted%22+sort%3Aupdated-desc).
+
+Submariner's success depends on growing the set of contributors to the project. Welcoming new contributors is a top priority of the project.
+
 ### Research notice
 
 Please note that this repository is participating in a study into sustainability


### PR DESCRIPTION
Start the development docs with a section welcoming new contributors and
linking to a query that shows GitHub Issues where they are needed.

This will ease the contribution process and make it more consistent.

Fixes: #665
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>