### PR TITLE
Add Shipyard image software to CI maintenance docs

### DIFF
--- a/src/content/development/building-testing/ci-maintenance/_index.en.md
+++ b/src/content/development/building-testing/ci-maintenance/_index.en.md
@@ -22,3 +22,18 @@ Basic Kubernetes Support | All non-latest supported versions | One defaults-only
 Full Kubernetes Support | All non-latest supported versions | Workflow to run all CI for all of the currently-supported, non-latest Kubernetes versions. Run periodically, on releases, or manually by adding the `e2e-all-k8s` label.
 Unsupported Kubernetes Cut-off | Oldest working version | One defaults-only E2E for the oldest Kubernetes version known to work with Submariner. This tests the cut-off version used by `subctl` to prevent installing Submariner in environments that are known to be unsupported.
 <!-- markdownlint-enable line-length -->
+
+## Shipyard Base Image Software
+
+Some versions of software used by the Shipyard base image are maintained manually and should be periodically updated.
+
+```shell
+ENV LINT_VERSION=<version> \
+    HELM_VERSION=<version> \
+    KIND_VERSION=<version> \
+    BUILDX_VERSION=<version> \
+    GH_VERSION=<version> \
+    YQ_VERSION=<version>
+```
+
+[submariner-io/shipyard/package/Dockerfile.shipyard-dapper-base](https://github.com/submariner-io/shipyard/blob/devel/package/Dockerfile.shipyard-dapper-base)


### PR DESCRIPTION
Document that the versions of software installed on the Shipyard base
image must be updated. This will make maintenance more consistent.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>