### PR TITLE
Add documentation for `subctl unexport`

### DIFF
--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -78,7 +78,24 @@ discoverable from other clusters in the Submariner deployment.
 |:-----------------------------|:----------------------------------------------------------------------------|
 | `--kubeconfig` `<string>`    | Absolute path(s) to the kubeconfig file(s) (default `$HOME/.kube/config`)
 | `--kubecontext` `<string>`   | Kubeconfig context to use
-| `--namespace` `<string>`     | Namespace in which the Service to be exported belongs
+| `--namespace` `<string>`     | Namespace to use
+
+If no `namespace` flag is specified, it uses the default namespace from the current context, if present, otherwise it uses `default`.
+
+### `unexport`
+
+#### `unexport service`
+
+`subctl unexport service [flags] <name>` removes the `ServiceExport` resource with the given name which in turn stops the Service of the
+same name from being exported to other clusters.
+
+#### `unexport service` flags
+
+| Flag                         | Description
+|:-----------------------------|:----------------------------------------------------------------------------|
+| `--kubeconfig` `<string>`    | Absolute path(s) to the kubeconfig file(s) (default `$HOME/.kube/config`)
+| `--kubecontext` `<string>`   | Kubeconfig context to use
+| `--namespace` `<string>`     | Namespace to use
 
 If no `namespace` flag is specified, it uses the default namespace from the current context, if present, otherwise it uses `default`.
 

--- a/src/content/operations/usage/_index.en.md
+++ b/src/content/operations/usage/_index.en.md
@@ -644,6 +644,17 @@ and the IP address **100.2.29.136** returned is the ClusterIP associated with th
 expected, as Submariner prefers to handle the traffic locally whenever possible.
 {{% /notice %}}
 
+##### 7. Stopping the service from being exported
+
+If you don't want to have the service exported to other clusters in the cluster set anymore, you can do so with `subctl unexport`:
+
+```bash
+$ subctl unexport service --namespace nginx-test nginx
+Service unexported successfully
+```
+
+Now, the service is no longer discoverable outside its cluster.
+
 #### Service Discovery for Services Deployed to Multiple Clusters
 
 Submariner follows this logic for service discovery across the cluster set:


### PR DESCRIPTION
Added documentation for the command itself and a small section in the
user guide.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>