### PR TITLE
Document running subctl diagnose from a Pod

### DIFF
--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -309,7 +309,7 @@ Below is a list of available sub-commands:
 |:-----------------------------|:----------------------------------------------------------------------------|
 | `--kubeconfig` `<string>`    | Absolute path(s) to the kubeconfig file(s) (default `$HOME/.kube/config`)
 | `--kubecontext` `<string>`   | Kubeconfig context to use
-| `--in-cluster`              | Use the in-cluster configuration to connect to Kubernetes. Use when running `diagnose` from a Pod in cluster
+| `--in-cluster`              | Use the in-cluster configuration to connect to Kubernetes.
 
 ### `gather`
 
@@ -534,8 +534,9 @@ The following steps are performed:
 
 ### Running `subctl diagnose` from a Pod in cluster
 
-`subctl` image containing the subctl binary can be used to run subctl from a Pod within the cluster. `subctl diagnose`
-command output can be accessed from the Pod's logs. `--in-cluster` has been added to `subctl diagnose` to support this use case.
+As of 0.12.0, a `subctl` image is provided for running the `subctl` binary from a Pod within a cluster. The output of
+`subctl diagnose` command output can be accessed from the Pod's logs. `--in-cluster` has been added to `subctl diagnose`
+to support this use case.
 
 #### Example running `subctl diagnose` using a Job
 
@@ -558,5 +559,5 @@ spec:
   backoffLimit: 0
 ```
 
-Created Pod can be accessed with label `job-name=submariner-diagnose`. A similar template can also be used to
-create a `CronJob` that runs `subctl diagnose` periodically.
+The resulting Pod with `subctl diagnose all --in-cluster` logs can be accessed with the label `job-name=submariner-diagnose`.
+A similar template can also be used to create a `CronJob` that runs `subctl diagnose` periodically.

--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -534,9 +534,8 @@ The following steps are performed:
 
 ### Running `subctl diagnose` from a Pod in cluster
 
-As of release 0.12.0, a new `subctl` image containing the subctl binary is now available in submariner repos. This can be
-used to run subctl from a Pod within the cluster. `subctl diagnose` command output can be accessed from the Pod's logs.
-A new flag, `--in-cluster` has been added to support this use case.
+`subctl` image containing the subctl binary can be used to run subctl from a Pod within the cluster. `subctl diagnose`
+command output can be accessed from the Pod's logs. `--in-cluster` has been added to `subctl diagnose` to support this use case.
 
 #### Example running `subctl diagnose` using a Job
 
@@ -559,4 +558,5 @@ spec:
   backoffLimit: 0
 ```
 
-A similar template can also be used to create a CronJob that runs `subctl diagnose` periodically.
+Created Pod can be accessed with label `job-name=submariner-diagnose`. A similar template can also be used to
+create a `CronJob` that runs `subctl diagnose` periodically.

--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -534,8 +534,8 @@ The following steps are performed:
 
 ### Running `subctl diagnose` from a Pod in cluster
 
-As of 0.12.0, a `subctl` image is provided for running the `subctl` binary from a Pod within a cluster. The output of
-the `subctl diagnose` command output can be accessed from the Pod's logs. The `--in-cluster` flag was added to
+As of 0.12.0, a [subctl](quay.io/submariner/subctl) image is provided for running the `subctl` binary from a Pod within a cluster.
+The output of the `subctl diagnose` command output can be accessed from the Pod's logs. The `--in-cluster` flag was added to
 `subctl diagnose` to support this use case.
 
 #### Example running `subctl diagnose` using a Job

--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -309,6 +309,7 @@ Below is a list of available sub-commands:
 |:-----------------------------|:----------------------------------------------------------------------------|
 | `--kubeconfig` `<string>`    | Absolute path(s) to the kubeconfig file(s) (default `$HOME/.kube/config`)
 | `--kubecontext` `<string>`   | Kubeconfig context to use
+| `--in-cluster`              | Use the in-cluster configuration to connect to Kubernetes. Use when running `diagnose` from a Pod in cluster
 
 ### `gather`
 
@@ -530,3 +531,32 @@ The following steps are performed:
 | `--kubeconfig` `<string>`        | Absolute path(s) to the kubeconfig file(s)
 | `--namespace` `<string>`         | Namespace in which Submariner is installed (default `submariner-operator`)
 | `--yes`                          | Automatically answer yes to confirmation prompt
+
+### Running `subctl diagnose` from a Pod in cluster
+
+As of release 0.12.0, a new `subctl` image containing the subctl binary is now available in submariner repos. This can be
+used to run subctl from a Pod within the cluster. `subctl diagnose` command output can be accessed from the Pod's logs.
+A new flag, `--in-cluster` has been added to support this use case.
+
+#### Example running `subctl diagnose` using a Job
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: submariner-diagnose
+  namespace: submariner-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: submariner-diagnose
+        image: quay.io/submariner/subctl:latest
+        command: ["subctl",  "diagnose", "all", "--in-cluster"]
+      restartPolicy: Never
+      serviceAccount: submariner-diagnose
+      serviceAccountName: submariner-diagnose
+  backoffLimit: 0
+```
+
+A similar template can also be used to create a CronJob that runs `subctl diagnose` periodically.

--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -535,8 +535,8 @@ The following steps are performed:
 ### Running `subctl diagnose` from a Pod in cluster
 
 As of 0.12.0, a `subctl` image is provided for running the `subctl` binary from a Pod within a cluster. The output of
-`subctl diagnose` command output can be accessed from the Pod's logs. `--in-cluster` has been added to `subctl diagnose`
-to support this use case.
+the `subctl diagnose` command output can be accessed from the Pod's logs. The `--in-cluster` flag was added to
+`subctl diagnose` to support this use case.
 
 #### Example running `subctl diagnose` using a Job
 


### PR DESCRIPTION
* Add `--in-cluster` flag to `subctl diganose`
* Add information on how to use `--in-cluster` flag and `subctl` image
  to run `subctl diagnose` from a Pod within cluster

Fixes #688

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>