### PR TITLE
Doc avoiding "new" in Website Style Guide

### DIFF
--- a/src/content/development/website/style-guide/_index.en.md
+++ b/src/content/development/website/style-guide/_index.en.md
@@ -49,3 +49,10 @@ project as related to submarine cables.
 Submariner follows ISO 8601 for date formats (YYYY-MM-DD or YYYY-MM).
 
 [kube docs guide]: https://kubernetes.io/docs/contribute/style/style-guide
+
+### Use Versions, not "New"
+
+Avoid referring to things as "new", as this will become out of date and require maintenance.
+Instead, document the versions that introduce or remove features:
+
+> As of 0.12.0, a `subctl` image is provided ...


### PR DESCRIPTION
Use versions instead of "new" for less maintenance.

Document this practice in the style guide for clarity and consistency.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>