### PR TITLE
Use Markdownlint to enforce capitalisation rules

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -15,3 +15,20 @@ no-inline-html:
     - p
     - span
     - ul
+
+# Enforce our capitalisation rules (where they're unambiguous)
+spelling:
+  names:
+    - Admiral
+    - ClusterSet
+    - Coastguard
+    - Globalnet
+    - IPsec
+    - iptables
+    - kind
+    - Kubernetes
+    - Lighthouse
+    - Shipyard
+    - subctl
+    - Submariner
+  code_blocks: false

--- a/src/content/community/contributor-roles/_index.en.md
+++ b/src/content/community/contributor-roles/_index.en.md
@@ -67,7 +67,7 @@ are expected to remain active contributors to the community.
   * Filing or commenting on issues on GitHub
   * Contributing to community discussions (e.g. meetings, Slack, email
     discussion forums, Stack Overflow)
-* Subscribed to [submariner-dev@googlegroups.com]
+* Subscribed to [`submariner-dev@googlegroups.com`]
 * Have read the [community] and [development] guides
 * Actively contributing
 * Sponsored by 2 committers. **Note the following requirements for sponsors**:
@@ -75,7 +75,7 @@ are expected to remain active contributors to the community.
     code/design/proposal review, coordinating on issues, etc.
   * Sponsors must be committers in at least 1 CODEOWNERS file either in any
     repo in the [Submariner org]
-* [Open an issue][membership request issue] against the submariner-io/submariner repo
+* [Open an issue][membership request issue] against the `submariner-io/submariner` repo
   * Ensure your sponsors are @mentioned on the issue
   * Complete every item on the checklist ([preview the current version of the member template][membership template])
   * Make sure that the list of contributions included is representative of
@@ -129,7 +129,7 @@ in an CODEOWNERS file:
 * Sponsored by two committers or project owners
   * With no objections from other committers or project owners
 * May either self-nominate or be nominated by a committer/owner
-* [Open an issue][committership request issue] against the submariner-io/submariner repo
+* [Open an issue][committership request issue] against the `submariner-io/submariner` repo
   * Ensure your sponsors are @mentioned on the issue
   * Complete every item on the checklist ([preview the current version of the committer template][committership template])
   * Make sure that the list of contributions included is representative of
@@ -141,7 +141,7 @@ in an CODEOWNERS file:
 ### Committer Responsibilities and Privileges
 
 The following apply to the part of codebase for which one would be a committer
-in an CODEOWNERS file:
+in a CODEOWNERS file:
 
 * Responsible for project quality control via [code reviews]
   * Focus on code quality and correctness, including testing and factoring
@@ -151,7 +151,7 @@ in an CODEOWNERS file:
 * Expected to be responsive to review requests as per [community expectations]
 * Assigned PRs to review related to project of expertise
 * Assigned test bugs related to project of expertise
-* Granted "read access" to submariner repo
+* Granted "read access" to the corresponding repository
 * May get a badge on PR and issue comments
 * Demonstrate sound technical judgement
 * Mentor contributors and reviewers
@@ -166,7 +166,7 @@ health the project. Project owners *MUST* set technical direction and make or
 approve design decisions for the project - either directly or through
 delegation of these responsibilities.
 
-**Defined by:** Member of the [submariner-owners GitHub team][owners team] and [`*`entry in all CODEOWNERS files][codeowners file].
+**Defined by:** Member of the [`submariner-owners` GitHub team][owners team] and [`*` entry in all CODEOWNERS files][codeowners file].
 
 ### Owner Requirements
 
@@ -226,7 +226,7 @@ The following apply to people who would be an owner:
 [development]: ../../development
 [community]: ..
 [Submariner org]: https://github.com/submariner-io
-[submariner-dev@googlegroups.com]: https://groups.google.com/forum/#!forum/submariner-dev
+[`submariner-dev@googlegroups.com`]: https://groups.google.com/forum/#!forum/submariner-dev
 [membership request issue]: https://github.com/submariner-io/submariner/issues/new?template=membership.md&title=REQUEST%3A%20New%20membership%20request%20for%20%3Cyour-GH-handle%3E
 [membership template]: https://github.com/submariner-io/submariner/blob/devel/.github/ISSUE_TEMPLATE/membership.md
 [committership request issue]: https://github.com/submariner-io/submariner/issues/new?template=committership.md&title=REQUEST%3A%20New%20committer%20rights%20request%20for%20%3Cyour-GH-handle%3E

--- a/src/content/community/getting-help/_index.en.md
+++ b/src/content/community/getting-help/_index.en.md
@@ -15,7 +15,7 @@ about the GitHub workflow [here](https://git-scm.com/book/en/v2/GitHub-Contribut
 
 #### Slack
 
-Share your ideas in the [#submariner channel](https://kubernetes.slack.com/archives/C010RJV694M) in Kubernetes' Slack. If you need it, you
+Share your ideas in the [`#submariner` channel](https://kubernetes.slack.com/archives/C010RJV694M) in Kubernetes' Slack. If you need it, you
 can [request an invite to Kubernetes' Slack instance](https://slack.k8s.io/).
 
 #### Community Calendar
@@ -26,5 +26,5 @@ The bi-weekly [Submariner Users & Community Meeting](https://tinyurl.com/54mcwfb
 
 #### Mailing List
 
-Join the [submariner-dev](https://groups.google.com/forum/#!forum/submariner-dev) or
-[submariner-users](https://groups.google.com/forum/#!forum/submariner-users) mailing lists.
+Join the [`submariner-dev`](https://groups.google.com/forum/#!forum/submariner-dev) or
+[`submariner-users`](https://groups.google.com/forum/#!forum/submariner-users) mailing lists.

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -18,7 +18,8 @@ This is a bugfix release:
 
 ## v0.11.0
 
-This release mainly focused on stability, bug fixes, and improving the integration between Submariner and Open Cluster Management via the [submariner-addon](https://github.com/open-cluster-management/submariner-addon).
+This release mainly focused on stability, bug fixes, and improving the integration between Submariner and Open Cluster Management
+via the [Submariner addon](https://github.com/open-cluster-management/submariner-addon).
 
 * `subctl cloud prepare` command now supports Google Cloud Platform as well as generic Kubernetes clusters.
 * `--ignore-requirements` flag was added to `subctl join` command which ignores Submariner requirements checks.
@@ -240,15 +241,15 @@ When upgrading to 0.7.0 on a cluster already running Submariner, the current sta
 
 > This release is focused on stability for Lighthouse.
 
-* Cleaner logging for submariner-engine.
-* Cleaner logging for submariner-route-agent.
-* Fixed issue with wrong token stored in `.subm` file ([submariner-operator#244](https://github.com/submariner-io/submariner-operator/issues/244)).
-* Added flag to disable the OpenShift CVO ([submariner-operator#235](https://github.com/submariner-io/submariner-operator/issues/235)).
-* Fixed several service discovery bugs ([submariner-operator#194](https://github.com/submariner-io/submariner-operator/issues/194), [submariner-operator#167](https://github.com/submariner-io/submariner-operator/issues/167)).
+* Cleaner logging for `submariner-engine`.
+* Cleaner logging for `submariner-route-agent`.
+* Fixed issue with wrong token stored in `.subm` file ([#244](https://github.com/submariner-io/submariner-operator/issues/244)).
+* Added flag to disable the OpenShift CVO ([#235](https://github.com/submariner-io/submariner-operator/issues/235)).
+* Fixed several service discovery bugs ([#194](https://github.com/submariner-io/submariner-operator/issues/194), [#167](https://github.com/submariner-io/submariner-operator/issues/167)).
 * Fixed several panics on nil network discovery.
 * Added checks to ensure the CIDRs for joining cluster don't overlap with existing ones.
 * Fix context handling related to service discovery/KubeFed
-  ([submariner-operator#180](https://github.com/submariner-io/submariner-operator/issues/180)).
+  ([#180](https://github.com/submariner-io/submariner-operator/issues/180)).
 * Use the correct CoreDNS image for OpenShift.
 
 ## v0.1.0 Submariner with some light
@@ -256,15 +257,15 @@ When upgrading to 0.7.0 on a cluster already running Submariner, the current sta
 > This release has focused on stability, bugfixes and making [Lighthouse](https://github.com/submariner-io/lighthouse) available as a
 > developer preview via `subctl` deployments.
 
-* Several bugfixes and enhancements around HA failover ([submariner#346](https://github.com/submariner-io/submariner/issues/346),
-  [submariner#348](https://github.com/submariner-io/submariner/pull/348),
-  [submariner#332](https://github.com/submariner-io/submariner/pull/332)).
+* Several bugfixes and enhancements around HA failover ([#346](https://github.com/submariner-io/submariner/issues/346),
+  [#348](https://github.com/submariner-io/submariner/pull/348),
+  [#332](https://github.com/submariner-io/submariner/pull/332)).
 * Migrated to DaemonSets for Submariner gateway deployment.
-* Added support for hostNetwork to remote Pod/Service connectivity ([submariner#298](https://github.com/submariner-io/submariner/issues/298)).
-* Auto detection and configuration of MTU for vx-submariner, jumbo frames support
-  ([submariner#301](https://github.com/submariner-io/submariner/issues/301)).
-* Support for updated strongSwan ([submariner#288](https://github.com/submariner-io/submariner/issues/288)).
-* Better iptables detection for some hosts ([submariner#227](https://github.com/submariner-io/submariner/pull/227)).
+* Added support for hostNetwork to remote Pod/Service connectivity ([#298](https://github.com/submariner-io/submariner/issues/298)).
+* Auto detection and configuration of MTU for `vx-submariner`, jumbo frames support
+  ([#301](https://github.com/submariner-io/submariner/issues/301)).
+* Support for updated strongSwan ([#288](https://github.com/submariner-io/submariner/issues/288)).
+* Better iptables detection for some hosts ([#227](https://github.com/submariner-io/submariner/pull/227)).
 
 > `subctl` and the Submariner Operator have the following improvements:
 

--- a/src/content/development/building-testing/ci-maintenance/_index.en.md
+++ b/src/content/development/building-testing/ci-maintenance/_index.en.md
@@ -36,7 +36,7 @@ ENV LINT_VERSION=<version> \
     YQ_VERSION=<version>
 ```
 
-[submariner-io/shipyard/package/Dockerfile.shipyard-dapper-base](https://github.com/submariner-io/shipyard/blob/devel/package/Dockerfile.shipyard-dapper-base)
+[`submariner-io/shipyard/package/Dockerfile.shipyard-dapper-base`](https://github.com/submariner-io/shipyard/blob/devel/package/Dockerfile.shipyard-dapper-base)
 
 ## Shflags Library Version
 
@@ -47,7 +47,7 @@ version is maintained in a special place and must be manually updated.
 SHFLAGS_VERSION=${SHFLAGS_VERSION:=<version>}
 ```
 
-[submariner-io/shipyard/scripts/shared/lib/shflags](https://github.com/submariner-io/shipyard/blob/devel/scripts/shared/lib/shflags)
+[`submariner-io/shipyard/scripts/shared/lib/shflags`](https://github.com/submariner-io/shipyard/blob/devel/scripts/shared/lib/shflags)
 
 ## GitHub actions
 

--- a/src/content/development/release-process/_index.en.md
+++ b/src/content/development/release-process/_index.en.md
@@ -150,7 +150,7 @@ Navigate to the [releases](https://github.com/submariner-io/releases) repository
 
 2) Fill in the general fields for the release with the `status` field set to `shipyard`. Also add the `shipyard` component with
    the hash of the desired or latest commit ID on which to base the release. To obtain the latest, first navigate to
-   the [shipyard project](https://github.com/submariner-io/shipyard). The heading above the file list shows the latest
+   the [Shipyard project](https://github.com/submariner-io/shipyard). The heading above the file list shows the latest
    commit on the devel branch including the first 7 hex digits of the commit ID hash.
 
    If this is not a final release, set the `pre-release` field to `true` (that is uncomment the `pre-release` line below).
@@ -172,9 +172,9 @@ Navigate to the [releases](https://github.com/submariner-io/releases) repository
 
 4) **Verify**:
 
-   * The [releases/release job](https://github.com/submariner-io/releases/actions/workflows/release.yml) passed.
+   * The [`releases/release` job](https://github.com/submariner-io/releases/actions/workflows/release.yml) passed.
    * The [Shipyard release](https://github.com/submariner-io/shipyard/releases) was created.
-   * The [submariner/shipyard-dapper-base image](https://github.com/submariner-io/shipyard/releases) is on Quay.
+   * The [`submariner/shipyard-dapper-base` image](https://github.com/submariner-io/shipyard/releases) is on Quay.
 
 5) Pull requests will be created for projects that consume Shipyard to update them to the new version in preparation for the subsequent
    steps. The automation will leave a comment with a list of them. Make sure all those PRs are merged and their release jobs pass.
@@ -227,24 +227,24 @@ Once the pull requests to pin the cloud-prepare, Lighthouse and Submariner proje
 
 3) **Verify**:
 
-   * The [releases/release job](https://github.com/submariner-io/releases/actions/workflows/release.yml) passed.
-   * The [cloud-prepare release](https://github.com/submariner-io/cloud-prepare/releases) was created.
+   * The [`releases/release` job](https://github.com/submariner-io/releases/actions/workflows/release.yml) passed.
+   * The [`cloud-prepare` release](https://github.com/submariner-io/cloud-prepare/releases) was created.
    * The [Lighthouse release](https://github.com/submariner-io/lighthouse/releases) was created.
    * The [Submariner release](https://github.com/submariner-io/submariner/releases) was created.
-   * The [submariner/submariner-gateway image](https://quay.io/repository/submariner/submariner-gateway?tab=tags) is on Quay.
-   * The [submariner/submariner-route-agent image](https://quay.io/repository/submariner/submariner-route-agent?tab=tags) is on Quay.
-   * The [submariner/submariner-globalnet image](https://quay.io/repository/submariner/submariner-globalnet?tab=tags) is on Quay.
-   * The [submariner/submariner-networkplugin-syncer image](https://quay.io/repository/submariner/submariner-networkplugin-syncer?tab=tags)
+   * The [`submariner/submariner-gateway` image](https://quay.io/repository/submariner/submariner-gateway?tab=tags) is on Quay.
+   * The [`submariner/submariner-route-agent` image](https://quay.io/repository/submariner/submariner-route-agent?tab=tags) is on Quay.
+   * The [`submariner/submariner-globalnet` image](https://quay.io/repository/submariner/submariner-globalnet?tab=tags) is on Quay.
+   * The [`submariner/submariner-networkplugin-syncer` image](https://quay.io/repository/submariner/submariner-networkplugin-syncer?tab=tags)
      is on Quay.
-   * The [submariner/lighthouse-agent image](https://quay.io/repository/submariner/lighthouse-agent?tab=tags) is on Quay.
-   * The [submariner/lighthouse-coredns image](https://quay.io/repository/submariner/lighthouse-coredns?tab=tags) is on Quay.
+   * The [`submariner/lighthouse-agent` image](https://quay.io/repository/submariner/lighthouse-agent?tab=tags) is on Quay.
+   * The [`submariner/lighthouse-coredns` image](https://quay.io/repository/submariner/lighthouse-coredns?tab=tags) is on Quay.
 
-4) Automation will create a pull request to pin submariner-operator to the released versions. Make sure that PRs is merged and the release
+4) Automation will create a pull request to pin `submariner-operator` to the released versions. Make sure that the PR is merged and the release
    job passes.
 
 ### Step 4: Create Operator and Charts Releases
 
-Once the pull request to pin submariner-operator has been merged, we can create the final release:
+Once the pull request to pin `submariner-operator` has been merged, we can create the final release:
 
 1) Update the release YAML file `status` field to `released`. Add the `submariner-operator` and `submariner-charts` components with their
    latest commit ID hashes.
@@ -266,12 +266,12 @@ Once the pull request to pin submariner-operator has been merged, we can create 
 
 3) **Verify**:
 
-   * The [releases/release job](https://github.com/submariner-io/releases/actions/workflows/release.yml) passed.
+   * The [`releases/release` job](https://github.com/submariner-io/releases/actions/workflows/release.yml) passed.
    * The [`subctl` artifacts](https://github.com/submariner-io/releases/releases) were released
-   * The [submariner-operator release](https://github.com/submariner-io/submariner-operator/releases) was created.
-   * The [submariner/submariner-operator image](https://quay.io/repository/submariner/submariner-operator?tab=tags) is on Quay.
+   * The [`submariner-operator` release](https://github.com/submariner-io/submariner-operator/releases) was created.
+   * The [`submariner/submariner-operator` image](https://quay.io/repository/submariner/submariner-operator?tab=tags) is on Quay.
 
-4) If the release wasn't marked as a `pre-release`, the releases/release job will also create pull requests in each consuming project to
+4) If the release wasn't marked as a `pre-release`, the `releases/release` job will also create pull requests in each consuming project to
    unpin the Shipyard Dapper base image version, that is set it back to `devel`. For ongoing development we want each project to
    automatically pick up the latest changes to the base image.
 
@@ -285,7 +285,7 @@ The [k8s-operatorhub/community-operators](https://github.com/k8s-operatorhub/com
 is a source for sharing Kubernetes Operators with the broader community via [OperatorHub.io](https://operatorhub.io/).
 OpenShift users will find Submariner's Operator in the official [Red Hat catalog](https://catalog.redhat.com/software/operators/explore).
 
-1) Clone the [submariner-operator](https://github.com/submariner-io/submariner-operator) repository.
+1) Clone the [`submariner-operator`](https://github.com/submariner-io/submariner-operator) repository.
 
 2) Make sure you have [`operator-sdk` v1 installed](https://v1-0-x.sdk.operatorframework.io/docs/installation/install-operator-sdk/).
 
@@ -329,8 +329,8 @@ OpenShift users will find Submariner's Operator in the official [Red Hat catalog
 
 Once the release and release notes are published, make an announcement to both Submariner mailing lists.
 
-* [submariner-dev](https://groups.google.com/g/submariner-dev)
-* [submariner-users](https://groups.google.com/g/submariner-users)
+* [`submariner-dev`](https://groups.google.com/g/submariner-dev)
+* [`submariner-users`](https://groups.google.com/g/submariner-users)
 
 See the [v0.8.0 email example](https://groups.google.com/g/submariner-users/c/2F8Fzvi4mS4).
 

--- a/src/content/development/security/reporting/_index.en.md
+++ b/src/content/development/security/reporting/_index.en.md
@@ -5,9 +5,9 @@ weight: 40
 
 Submariner welcomes and appreciates responsible disclosure of security vulnerabilities.
 
-If you know of a security issue with Submariner, please report it to submariner-security@googlegroups.com. [Submariner Project
-Owners](https://submariner.io/community/contributor-roles/#project-owner) receive security disclosures by default. They may share
-disclosures with others as required to make and propagate fixes.
+If you know of a security issue with Submariner, please report it to [`submariner-security@googlegroups.com`](mailto:submariner-security@googlegroups.com).
+[Submariner Project Owners](https://submariner.io/community/contributor-roles/#project-owner) receive security disclosures by default.
+They may share disclosures with others as required to make and propagate fixes.
 
 Submariner aspires to follow the [Kubernetes security reporting process](https://kubernetes.io/docs/reference/issues-security/security/),
 but is far too small of a project to implement those practices. Where applicable, Submariner will follow the principles of the Kubernetes

--- a/src/content/development/shipyard/_index.en.md
+++ b/src/content/development/shipyard/_index.en.md
@@ -66,7 +66,7 @@ in the Shipyard directory. This creates a local image with your changes availabl
 Shipyard ships a [Makefile.inc] file which defines these basic targets:
 
 * **[clusters](#clusters):** Creates the kind-based cluster environment.
-* **[deploy](#deploy)** : Deploys submariner components in the cluster environment (depends on clusters).
+* **[deploy](#deploy)** : Deploys Submariner components in the cluster environment (depends on clusters).
 * **[clean-clusters](#cleanclusters):** Deletes the kind environment (if it exists) and any residual resources.
 * **[clean-generated](#cleangenerated):** Deletes all generated files.
 * **[clean](#clean):** Cleans everything up (running clusters and generated files).
@@ -150,7 +150,7 @@ Respected variables:
 * **QUAY_USERNAME, QUAY_PASSWORD:** Needed in order to log in to Quay.
 * **release_images:** One or more image names to release separated by spaces.
 * **release_tag:** A tag to use for the release (default is *latest*).
-* **repo:** The Quay repo to use (default is *quay.io/submariner*).
+* **repo:** The Quay repo to use (default is *`quay.io/submariner`*).
 
 ## Specific Makefile Targets
 

--- a/src/content/development/shipyard/advanced/_index.en.md
+++ b/src/content/development/shipyard/advanced/_index.en.md
@@ -16,13 +16,13 @@ caching capabilities to speed up local and pull request CI builds, by utilizing 
 
 The script accepts several flags:
 
-* **tag:** The tag to set for the local image (defaults to *dev*).
-* **repo:** The repo portion to use for the image name.
-* **image (-i):** The image name itself.
-* **dockerfile (-f):** The Dockerfile to build the image from.
-* **[no]cache:** Turns the caching on (or off).
+* **`tag`**: The tag to set for the local image (defaults to *dev*).
+* **`repo`**: The repo portion to use for the image name.
+* **`image` (`-i`)**: The image name itself.
+* **`dockerfile` (`-f`)**: The Dockerfile to build the image from.
+* **`[no]cache`**: Turns the caching on (or off).
 
-For example, to build the submariner image use:
+For example, to build the `submariner` image use:
 
 ```bash
 ${SCRIPTS_DIR}/build_image.sh -i submariner -f package/Dockerfile
@@ -41,10 +41,10 @@ on the root of the settings file to determine defaults.
 
 The possible settings are:
 
-* **broker**: Special key to mark the broker, set to anything to select a broker. By default, the first cluster is selected.
-* **cni**: Which CNI to deploy on the cluster, currently supports `weave` and `ovn` (leave empty or unset for `kindnet`).
-* **nodes**: A space separated list of nodes to deploy, supported types are `control-plane` and `worker`.
-* **submariner**: If Submariner should be deployed, set to `true`. Otherwise, leave unset (or set to `false` explicitly).
+* **`broker`**: Special key to mark the broker, set to anything to select a broker. By default, the first cluster is selected.
+* **`cni`**: Which CNI to deploy on the cluster, currently supports `weave` and `ovn` (leave empty or unset for `kindnet`).
+* **`nodes`**: A space separated list of nodes to deploy, supported types are `control-plane` and `worker`.
+* **`submariner`**: If Submariner should be deployed, set to `true`. Otherwise, leave unset (or set to `false` explicitly).
 
 For example, a basic settings file that deploys a couple of clusters with weave CNI:
 
@@ -81,14 +81,14 @@ same name). These flags affect how the clusters are deployed (and possibly influ
 
 Flags of note:
 
-* **k8s_version:** Allows to specify the Kubernetes version that [kind](https://kind.sigs.k8s.io/) will deploy. Available versions can be
+* **`k8s_version`**: Allows to specify the Kubernetes version that [kind](https://kind.sigs.k8s.io/) will deploy. Available versions can be
 found [here](https://hub.docker.com/r/kindest/node/tags).
 
   ```bash
   make clusters CLUSTERS_ARGS='--k8s_version 1.18.0'
   ```
 
-* **globalnet:** When set, deploys the clusters with overlapping Pod & Service CIDRs to simulate this scenario.
+* **`globalnet`**: When set, deploys the clusters with overlapping Pod & Service CIDRs to simulate this scenario.
 
   ```bash
   make clusters CLUSTERS_ARGS='--globalnet'
@@ -105,19 +105,19 @@ cluster hasn't been deployed yet).
 Flags of note (see the flags defined in [deploy.sh](https://github.com/submariner-io/shipyard/blob/devel/scripts/shared/deploy.sh)
 for the full list):
 
-* **deploytool:** Specifies the deployment tool to use: `operator` (default), `helm`, `bundle` or `ocm`.
+* **`deploytool`**: Specifies the deployment tool to use: `operator` (default), `helm`, `bundle` or `ocm`.
 
   ```bash
   make deploy DEPLOY_ARGS='--deploytool operator'
   ```
 
-* **deploytool_broker_args:** Any extra arguments to pass to the deploy tool when deploying the broker.
+* **`deploytool_broker_args`**: Any extra arguments to pass to the deploy tool when deploying the broker.
 
   ```bash
   make deploy DEPLOY_ARGS='--deploytool operator --deploytool_broker_args "--components service-discovery,connectivity"'
   ```
 
-* **deploytool_submariner_args:** Any extra arguments to pass to the deploy tool when deploying Submariner.
+* **`deploytool_submariner_args`**: Any extra arguments to pass to the deploy tool when deploying Submariner.
 
   ```bash
   make deploy DEPLOY_ARGS='--deploytool operator --deploytool_submariner_args "--cable-driver wireguard"'
@@ -128,13 +128,13 @@ The deploy script also has flags that group common options together for easier u
 For example, the [`service_discovery` flag in `deploy.sh`](https://github.com/submariner-io/shipyard/blob/devel/scripts/shared/deploy.sh)
 will handle the `--components service-discovery,connectivity` flags mentioned above. Other examples:
 
-* **globalnet:** When set, deploys Submariner with the globalnet controller, and assigns a unique Global CIDR to each cluster.
+* **`globalnet`**: When set, deploys Submariner with the Globalnet controller, and assigns a unique Global CIDR to each cluster.
 
   ```bash
   make deploy DEPLOY_ARGS='--globalnet'
   ```
 
-* **cable_driver:** Override the default cable driver to configure the tunneling method for connections between clusters.
+* **`cable_driver`**: Override the default cable driver to configure the tunneling method for connections between clusters.
 
   ```bash
   make deploy DEPLOY_ARGS='--cable_driver wireguard'

--- a/src/content/development/website/_index.en.md
+++ b/src/content/development/website/_index.en.md
@@ -11,7 +11,7 @@ The Submariner documentation website is based on Hugo, Grav,
 You can always click the **Edit this page** link at the top right of each page, but if you want to test your changes locally before
 submitting you can:
 
-1. Fork the [submariner-io/submariner-website](https://github.com/submariner-io/submariner-website/fork) on GitHub.
+1. Fork the [`submariner-io/submariner-website`](https://github.com/submariner-io/submariner-website/fork) project on GitHub.
 2. Check out your copy locally:
 
     ```bash

--- a/src/content/getting-started/_index.en.md
+++ b/src/content/getting-started/_index.en.md
@@ -12,10 +12,10 @@ For more information about Submariner's architecture, please refer to the [Archi
 
 ### The Broker
 
-The Broker is an API that all participating clusters are given access to, and where two objects are exchanged via CRDs:
+The Broker is an API that all participating clusters are given access to, and where two objects are exchanged via CRDs in `.submariner.io`:
 
-* Cluster(.submariner.io): defines a participating cluster and its IP CIDRs.
-* Endpoint(.submariner.io): defines a connection endpoint to a cluster, and the reachable cluster IPs from the endpoint.
+* Cluster: defines a participating cluster and its IP CIDRs.
+* Endpoint: defines a connection endpoint to a cluster, and the reachable cluster IPs from the endpoint.
 
 The Broker must be deployed on a single Kubernetes cluster. This cluster’s API server must be reachable by all Kubernetes clusters connected
 by Submariner. It can be a dedicated cluster, or one of the connected clusters.

--- a/src/content/getting-started/architecture/gateway-engine/_index.en.md
+++ b/src/content/getting-started/architecture/gateway-engine/_index.en.md
@@ -38,7 +38,7 @@ active instance fail.
 
 {{% notice info %}}
 The Gateway Engine is deployed as a DaemonSet that is configured to only run
-on nodes labelled with "submariner.io/gateway=true".
+on nodes labelled with `submariner.io/gateway=true`.
 {{% /notice %}}
 
 The active Gateway Engine communicates with the central Broker to advertise

--- a/src/content/getting-started/architecture/globalnet/_index.en.md
+++ b/src/content/getting-started/architecture/globalnet/_index.en.md
@@ -25,7 +25,7 @@ Globalnet is a virtual network specifically to support Submariner's multi-cluste
 subnet from this virtual Global Private Network, configured as new cluster parameter `GlobalCIDR` (e.g. 242.0.0.0/8) which is
 configurable at time of deployment. User can also manually specify GlobalCIDR for each cluster that is joined to the Broker using the flag
 ```globalnet-cidr``` passed to ```subctl join``` command. If Globalnet is not enabled in the Broker or if a GlobalCIDR is preconfigured in
-the cluster, the supplied globalnet-cidr will be ignored.
+the cluster, the supplied Globalnet CIDR will be ignored.
 
 ### Cluster-scope global egress IPs
 
@@ -55,7 +55,7 @@ Gateway node of the cluster.
 ![Figure 2 - Globalnet priority](/images/globalnet/globalnet-priority.png)
 <!-- Image Source: https://docs.google.com/presentation/d/180CtHZnr9PP5Rh98VEmkQz3ovc5AGXG9wosoHMLhgaY/edit -->
 
-### submariner-globalnet
+### `submariner-globalnet`
 
 Submariner Globalnet is a component that provides cross-cluster connectivity from pods to remote services using their global IPs. Compiled as
 binary `submariner-globalnet`, it is responsible for maintaining a pool of global IPs, allocating IPs from the global IP pool to pods and
@@ -87,7 +87,7 @@ Globalnet currently relies on `kube-proxy` and thus will only work with deployme
 
 Connectivity is only part of the solution as pods still need to know the IPs of services on remote clusters.
 
-This is achieved by enhancing [lighthouse](https://github.com/submariner-io/lighthouse) with support for Globalnet. The Lighthouse
+This is achieved by enhancing [Lighthouse](https://github.com/submariner-io/lighthouse) with support for Globalnet. The Lighthouse
 controller uses a service's global IP when creating the `ServiceImport` for services of type `ClusterIP`. For headless services,
 backing pod's global IP is used when creating the `EndpointSlice` resources to be distributed to other clusters.
 The [Lighthouse plugin](https://github.com/submariner-io/lighthouse/tree/devel/plugin/lighthouse) then uses the global IPs when

--- a/src/content/getting-started/quickstart/external/_index.md
+++ b/src/content/getting-started/quickstart/external/_index.md
@@ -325,13 +325,13 @@ On test-vm, check the console log of HTTP server that there are accesses from po
 {{% notice note %}}
 Currently, __headless__ service without selector is not supported for Globalnet,
 therefore service without selector needs to be used.
-This feature is under discussion in [submariner-io/submariner#1537](https://github.com/submariner-io/submariner/issues/1537).
+This feature is under discussion in [#1537](https://github.com/submariner-io/submariner/issues/1537).
 {{% /notice %}}
 
 {{% notice note %}}
 Currently, DNS resolution for service without selector is not supported,
 therefore global IPs need to be used to access to the external hosts.
-This feature is under discussion in [submariner-io/lighthouse#603](https://github.com/submariner-io/lighthouse/issues/603).
+This feature is under discussion in [#603](https://github.com/submariner-io/lighthouse/issues/603).
 Note that there is a workaround to make it resolvable by manually creating endpointslice, as described [here](https://github.com/submariner-io/lighthouse/issues/603#issuecomment-901944297).
 {{% /notice %}}
 

--- a/src/content/getting-started/quickstart/kind/_index.md
+++ b/src/content/getting-started/quickstart/kind/_index.md
@@ -30,8 +30,9 @@ cd submariner-operator
 make deploy using=lighthouse
 ```
 
-By default, the automation configuration in the submariner-io/submariner-operator repository deploys two clusters, with cluster1 configured as
-the Broker. See the [settings](https://github.com/submariner-io/submariner-operator/blob/devel/.shipyard.e2e.yml) file for details.
+By default, the automation configuration in the `submariner-io/submariner-operator` repository deploys two clusters, with cluster1
+configured as the Broker.
+See the [settings](https://github.com/submariner-io/submariner-operator/blob/devel/.shipyard.e2e.yml) file for details.
 
 Once you become familiar with Submariner's basics, you may want to visit the
 [Building and Testing page](../../../development/building-testing/) to learn more about customizing your Submariner development deployment.

--- a/src/content/getting-started/quickstart/openshift/gcp-lb/_index.md
+++ b/src/content/getting-started/quickstart/openshift/gcp-lb/_index.md
@@ -9,7 +9,7 @@ clusters on GCP leveraging a cloud network load balancer service in front of the
 
 The main benefit of this mode is that there is no need to dedicate specialized nodes with a public IP
 address to act as gateways. The administrator only needs to manually label any existing
-node or nodes in each cluster as Submariner gateways, and the submariner-operator will take care of creating a LoadBalancer
+node or nodes in each cluster as Submariner gateways, and the Submariner Operator will take care of creating a LoadBalancer
 type Service pointing to the active Submariner gateway.
 
 {{% notice warning %}}

--- a/src/content/getting-started/quickstart/openshift/globalnet/_index.md
+++ b/src/content/getting-started/quickstart/openshift/globalnet/_index.md
@@ -69,7 +69,7 @@ When the cluster deployment completes, directions for accessing your cluster, in
 
 To install Submariner with multi-cluster service discovery and support for overlapping CIDRs follow the steps below.
 
-#### Use cluster-a as Broker with service discovery and globalnet enabled
+#### Use cluster-a as Broker with service discovery and Globalnet enabled
 
 ```bash
 subctl deploy-broker  --kubeconfig cluster-a/auth/kubeconfig --globalnet

--- a/src/content/operations/cleanup/_index.en.md
+++ b/src/content/operations/cleanup/_index.en.md
@@ -115,7 +115,7 @@ Make sure KUBECONFIG for all participating clusters is exported and all particip
    EOF
    ```
 
-   This deletes the lighthouse entry from the `Data` section in `Corefile` of the configmap.
+   This deletes the Lighthouse entry from the `Data` section in `Corefile` of the configmap.
 
    ```bash
    #lighthouse-start AUTO-GENERATED SECTION. DO NOT EDIT
@@ -125,7 +125,7 @@ Make sure KUBECONFIG for all participating clusters is exported and all particip
    #lighthouse-end
    ```
 
-   Verify that the lighthouse entry is deleted from `Corefile` of `dns-default` configmap by running
+   Verify that the Lighthouse entry is deleted from `Corefile` of `dns-default` configmap by running
    following command on an OpenShift cluster
 
    ```bash
@@ -133,7 +133,7 @@ Make sure KUBECONFIG for all participating clusters is exported and all particip
    ```
 
    For Kubernetes deployments, manually edit the `Corefile` of `coredns` configmap and delete the
-   lighthouse entry by issuing below commands
+   Lighthouse entry by issuing below commands
 
    ```bash
    kubectl edit cm coredns -n kube-system
@@ -145,7 +145,7 @@ Make sure KUBECONFIG for all participating clusters is exported and all particip
    kubectl rollout restart -n kube-system deployment/coredns
    ```
 
-   Verify that the lighthouse entry is deleted from `Data` section in `Corefile` of `dns-default`
+   Verify that the Lighthouse entry is deleted from `Data` section in `Corefile` of `dns-default`
    config map by running following command on a Kubernetes cluster
 
    ```bash

--- a/src/content/operations/deployment/calico/_index.en.md
+++ b/src/content/operations/deployment/calico/_index.en.md
@@ -20,8 +20,8 @@ and allows Submariner to support cross-cluster connectivity.
 
 {{% notice note %}}
 When using [Submariner Globalnet](../../../getting-started/architecture/globalnet) with Calico, please avoid the default
-globalnet-cidr (i.e., 242.0.0.0/8) as its used internally within Calico. You can explicitly specify
-a non-overlapping globalnet-cidr while deploying Submariner.
+Globalnet CIDR (i.e., 242.0.0.0/8) as it is used internally within Calico. You can explicitly specify
+a non-overlapping Globalnet CIDR while deploying Submariner.
 {{% /notice %}}
 
 As an example, consider two clusters, East and West, deployed with the Calico network plugin

--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -55,7 +55,7 @@ contains the following details:
 |:--------------------------------------|:---------------------------------------------------------------------------------------------------|
 | `--kubeconfig` `<string>`             | Absolute path(s) to the kubeconfig file(s) (default `$HOME/.kube/config`)
 | `--kubecontext` `<string>`            | kubeconfig context to use
-| `--repository` `<string>`             | The repository from where the various Submariner images will be sourced (default "quay.io/submariner")
+| `--repository` `<string>`             | The repository from where the various Submariner images will be sourced (default `quay.io/submariner`)
 | `--version` `<string>`                | Image version (default image tag "devel")
 | `--components <strings>`              | Comma-separated list of components to be installed - any of `service-discovery`,`connectivity`. The default is: `service-discovery`,`connectivity`
 | `--globalnet`                         | Enable support for overlapping Cluster/Service CIDRs in connecting clusters (default disabled)
@@ -143,9 +143,9 @@ deployment.
 <!-- markdownlint-disable line-length -->
 | Flag                                    | Description
 |:----------------------------------------|:----------------------------------------------------------------------------|
-| `--repository` `<string>`               | The repository from where the various Submariner images will be sourced (default "quay.io/submariner")
+| `--repository` `<string>`               | The repository from where the various Submariner images will be sourced (default `quay.io/submariner`)
 | `--version` `<string>`                  | Image version (default image tag "devel")
-| `--image-override` `<string>=<string>`  | Component image override. This flag can be used more than once (example: --image-override=submariner=quay.io/myUser/submariner:latest)
+| `--image-override` `<string>=<string>`  | Component image override. This flag can be used more than once (example: `--image-override=submariner=quay.io/myUser/submariner:latest`)
 <!-- markdownlint-enable line-length -->
 
 #### `join` flags (health check)
@@ -481,7 +481,7 @@ This command uninstalls Submariner and its components.
 The following steps are performed:
 
 * Delete Submariner ClusterRoles and ClusterRoleBindings.
-* Delete the submariner.io CRDs.
+* Delete the `submariner.io` CRDs.
 * Delete the routing entries (iptables/routes/ipsets) programmed on the nodes.
 * Delete the tunnel interfaces created for internal/external communication.
 * Delete the Submariner namespace.
@@ -493,5 +493,5 @@ The following steps are performed:
 | Flag                             | Description
 |:---------------------------------|:--------------------------------------------------------------------------------------------------------------------------|
 | `--kubeconfig` `<string>`        | Absolute path(s) to the kubeconfig file(s)
-| `--namespace` `<string>`         | Namespace in which Submariner is installed (default "submariner-operator")
+| `--namespace` `<string>`         | Namespace in which Submariner is installed (default `submariner-operator`)
 | `--yes`                          | Automatically answer yes to confirmation prompt

--- a/src/content/operations/known-issues/_index.en.md
+++ b/src/content/operations/known-issues/_index.en.md
@@ -32,4 +32,4 @@ oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submar
 oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submariner-globalnet
 ```
 
-This is handled automatically in `subctl` and submariner-addon.
+This is handled automatically in `subctl` and the Submariner addon.

--- a/src/content/operations/nat-traversal/_index.en.md
+++ b/src/content/operations/nat-traversal/_index.en.md
@@ -28,12 +28,12 @@ Resolvers are evaluated one by one, using the result of the first one to succeed
 `<resolver>` should be written in the following form: `method:parameter`, and the
 following methods are implemented:
 
-| Method   | Parameter                                                     | Notes                                                  |
-|:---------|:--------------------------------------------------------------|:-------------------------------------------------------|
-|   api    | HTTPS endpoint to contact, for example api.ipify.org          | The result body is inspected looking for the IP address|
-|   lb     | LoadBalancer Service name in the submariner-operator namespace| A network load balancer should be used                 |
-|   ipv4   | Fixed IPv4 address used as public IP                          |                                                        |
-|   dns    | FQDN DNS entry to be resolved                                 | The A entry of the FQDN will be resolved and used      |
+| Method   | Parameter                                                        | Notes                                                  |
+|:---------|:-----------------------------------------------------------------|:-------------------------------------------------------|
+|   api    | HTTPS endpoint to contact, for example api.ipify.org             | The result body is inspected looking for the IP address|
+|   lb     | LoadBalancer Service name in the `submariner-operator` namespace | A network load balancer should be used                 |
+|   ipv4   | Fixed IPv4 address used as public IP                             |                                                        |
+|   dns    | FQDN DNS entry to be resolved                                    | The A entry of the FQDN will be resolved and used      |
 
 For example, when using a fixed public IPv4 address for a gateway, this can be used:
 

--- a/src/content/operations/troubleshooting/_index.en.md
+++ b/src/content/operations/troubleshooting/_index.en.md
@@ -253,7 +253,7 @@ In the output look for something like this:
 If the entries highlighted above are missing or `ServiceIp` is incorrect, it means CoreDNS wasn't configured correctly. It can be fixed by
 running `kubectl edit configmap coredns` and making the changes manually. You may need to repeat this step on every cluster.
 
-##### Check submariner-lighthouse-agent
+##### Check `submariner-lighthouse-agent`
 
 Next we check if the `submariner-lighthouse-agent` is properly running. Run `kubectl -n submariner-operator get pods
 submariner-lighthouse-agent` and check the status of Pods.


### PR DESCRIPTION
Our wordlist
(<https://submariner.io/development/website/style-guide/#submarinerio-word-list>)
is mostly concerned with capitalisation, and most of our
capitalisation rules are unambiguous (not context-dependent).
Markdownlint can enforce this for us
(<https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md044---proper-names-should-have-the-correct-capitalization>)
so configure it to do so.

Adding this requires fixing a number of occurrences of non-capitalised
names, typically by placing them in a code block (e.g. for container
image names, repository names).

Signed-off-by: Stephen Kitt <skitt@redhat.com>