### PR TITLE
Add OpenStack to capitalization linting

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -28,6 +28,7 @@ spelling:
     - kind
     - Kubernetes
     - Lighthouse
+    - OpenStack
     - Shipyard
     - subctl
     - Submariner


### PR DESCRIPTION
The word "OpenStack" is not currently used in the docs, but it is
proposed to be introduced in submariner-io/submariner-website#729 and
feedback on that PR included needing to follow this scheme.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>