### PR TITLE
Link the linting dictionary to the style guide

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -17,6 +17,8 @@ no-inline-html:
     - ul
 
 # Enforce our capitalisation rules (where they're unambiguous)
+# Terms listed here should also be listed in the style guide in
+# src/content/development/website/style-guide/_index.en.md
 spelling:
   names:
     - Admiral

--- a/src/content/development/website/style-guide/_index.en.md
+++ b/src/content/development/website/style-guide/_index.en.md
@@ -18,6 +18,7 @@ A list of Submariner-specific terms and words to be used consistently across
 the site.
 
 <!-- markdownlint-disable line-length -->
+<!-- Terms listed here should be listed in .markdownlint.yml if their use is unambiguous -->
 Term | Usage
 :--- | :----
 Admiral | The project name *Admiral* should always be capitalized.
@@ -32,6 +33,7 @@ K8s | The project nickname *K8s* should typically be expanded to "Kubernetes".
 kind | The tool *kind* consistently uses all-lowercase. Follow their convention, but avoid starting a sentence with "kind".
 Lighthouse | The project name *Lighthouse* should always be capitalized.
 Operator | The design pattern *Operator* should always be capitalized.
+OpenStack | The project name *OpenStack* should always be capitalized and camel-cased.
 Shipyard | The project name *Shipyard* should always be capitalized.
 `subctl` | The artifact `subctl` should not be capitalized and should be formatted in code style.
 Submariner | The project name *Submariner* should always be capitalized.


### PR DESCRIPTION
Terms shouldn't be added to the linting dictionary without a
corresponding entry in the style guide, and terms in the style guide
should be included in the linting dictionary if their use is
unambiguous.

Add the missing OpenStack entry in the style guide.

Signed-off-by: Stephen Kitt <skitt@redhat.com>