### PR TITLE
Clarify K8s 1.17 is not supported, only tested

### DIFF
--- a/src/content/getting-started/_index.en.md
+++ b/src/content/getting-started/_index.en.md
@@ -31,7 +31,8 @@ Submariner has a few requirements to get started:
 
 * At least two Kubernetes clusters, one of which is designated to serve as the central Broker that is accessible by all of your connected
 clusters; this can be one of your connected clusters, or a dedicated cluster.
-* Minimum supported Kubernetes version is 1.17.
+* The oldest [tested Kubernetes version](../development/building-testing/ci-maintenance/#kubernetes-versions) is 1.17.
+  Older versions are known not to work with Submariner.
 * Non-overlapping Pod and Service CIDRs between clusters. This is to prevent routing conflicts. For cases where addresses **do
 overlap**, [Globalnet](./architecture/globalnet) can be set up.
 * IP reachability between the gateway nodes. When connecting two clusters, the gateways must have at least one-way connectivity


### PR DESCRIPTION
Only the Kubernetes versions supported by upstream K8s are supported by
Submariner. K8s 1.17 is the last known working version, and is tested to
help maintain code that warns against installing on non-working
versions, but is not supported.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>