### PR TITLE
Document Globalnet GKE pre-requisites

### DIFF
--- a/src/content/getting-started/quickstart/managed-kubernetes/gke/_index.md
+++ b/src/content/getting-started/quickstart/managed-kubernetes/gke/_index.md
@@ -108,19 +108,18 @@ gcloud compute firewall-rules create "udp-out-4800" --allow=udp:4800 --direction
 
 ### Preparation: Globalnet
 
-Submariner Globalnet internally creates a Service with externalIPs for every exported service and sets the
-externalIPs to the globalIP assigned to the respective Service. By default, GKE clusters do not allow services
-to be created with ExternalIPs as it deploys the
-[DenyServiceExternalIPs](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#denyserviceexternalips)
-admission controller. If you are planning to install Submariner Globalnet on the clusters, please make sure that you
-disable the admission controller by running the following command.
+Submariner Globalnet internally creates a Service with external IPs for every exported Service and sets the `ExternalIPs` to the global IP
+assigned to the respective Service. By default, GKE clusters do not allow Services to be created with `ExternalIPs`, as it deploys the
+[DenyServiceExternalIPs admission
+controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#denyserviceexternalips). If you are planning to
+install Submariner Globalnet, please make sure that you disable the admission controller by running the following command.
 
 ``` bash
 gcloud container clusters update <cluster-name> --enable-service-externalips
 ```
 
-You can further restrict the usage of Service with externalIPs to selected service-accounts by following the step-2
-captured in the Prerequisite section of [Globalnet](https://submariner.io/getting-started/architecture/globalnet/) page.
+You can further restrict the usage of Services with external IPs to selected Service Accounts as documented in the
+[Globalnet Prerequisites](https://submariner.io/getting-started/architecture/globalnet/#prerequisites).
 
 After this, the clusters are finally ready for Submariner!
 

--- a/src/content/getting-started/quickstart/managed-kubernetes/gke/_index.md
+++ b/src/content/getting-started/quickstart/managed-kubernetes/gke/_index.md
@@ -106,6 +106,22 @@ gcloud compute firewall-rules create "udp-out-4500" --allow=udp:4500 --direction
 gcloud compute firewall-rules create "udp-out-4800" --allow=udp:4800 --direction=OUT
 ```
 
+### Preparation: Globalnet
+
+Submariner Globalnet internally creates a Service with externalIPs for every exported service and sets the
+externalIPs to the globalIP assigned to the respective Service. By default, GKE clusters do not allow services
+to be created with ExternalIPs as it deploys the
+[DenyServiceExternalIPs](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#denyserviceexternalips)
+admission controller. If you are planning to install Submariner Globalnet on the clusters, please make sure that you
+disable the admission controller by running the following command.
+
+``` bash
+gcloud container clusters update <cluster-name> --enable-service-externalips
+```
+
+You can further restrict the usage of Service with externalIPs to selected service-accounts by following the step-2
+captured in the Prerequisite section of [Globalnet](https://submariner.io/getting-started/architecture/globalnet/) page.
+
 After this, the clusters are finally ready for Submariner!
 
 ## Deploy Submariner


### PR DESCRIPTION
By default, GKE clusters do not allow services to be created with
ExternalIPs as it deploys the DenyServiceExternalIPs admission controller.
When deploying Globalnet on GKE clusters, the admission controller
has to be explicitly disabled. This PR captures this prerequisite.

Fixes: https://github.com/submariner-io/submariner-website/issues/742
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>