### PR TITLE
Ignore SubM Tweet URLs that 404 in GHA infra

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -13,6 +13,9 @@
       "pattern": "^http://localhost:"
     },
     {
+      "pattern": "^https://twitter.com/submarinerio/status/[0-9]+"
+    },
+    {
       "pattern": "^/images/"
     }
   ]


### PR DESCRIPTION
It seems that links to Tweets 404 in GitHub Action infra, causing our
link check job to fail, although they pass with the same link check
tooling locally and the links actually work.

This will fix the Periodic GHA workflow.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>