### PR TITLE
Add GCP to indexes, fix weights

### DIFF
--- a/src/content/getting-started/quickstart/_index.en.md
+++ b/src/content/getting-started/quickstart/_index.en.md
@@ -13,5 +13,6 @@ weight = 20
   * [On AWS](openshift/aws)
   * [On AWS with Globalnet](openshift/globalnet)
   * [On Azure](openshift/azure)
+  * [On GCP](openshift/gcp-lb)
   * [Hybrid vSphere and AWS](openshift/vsphere-aws)
 * [External Network (Experimental)](external)

--- a/src/content/getting-started/quickstart/openshift/_index.md
+++ b/src/content/getting-started/quickstart/openshift/_index.md
@@ -7,4 +7,5 @@ weight: 30
 * [On AWS](aws)
 * [On AWS with Globalnet](globalnet)
 * [On Azure](azure)
+* [On GCP](gcp-lb)
 * [Hybrid vSphere and AWS](vsphere-aws)

--- a/src/content/getting-started/quickstart/openshift/gcp-lb/_index.md
+++ b/src/content/getting-started/quickstart/openshift/gcp-lb/_index.md
@@ -1,7 +1,7 @@
 ---
 date: 2020-02-21T13:36:18+01:00
 title: "On GCP (LoadBalancer mode)"
-weight: 20
+weight: 35
 ---
 
 This quickstart guide covers the necessary steps to deploy two OpenShift Container Platform (OCP)

--- a/src/content/getting-started/quickstart/openshift/globalnet/_index.md
+++ b/src/content/getting-started/quickstart/openshift/globalnet/_index.md
@@ -1,7 +1,7 @@
 ---
 date: 2020-02-21T13:36:18+01:00
 title: "On AWS with Globalnet"
-weight: 30
+weight: 25
 ---
 
 This quickstart guide covers the necessary steps to deploy two OpenShift Container Platform (OCP) clusters on AWS with


### PR DESCRIPTION
1. Add gcp-lb/_index.md to
   src/content/getting-started/quickstart/_index.en.md
2. Increase its weight so that it is after `On AWS with Globalnet`
   section

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>