### PR TITLE
Ignore failing link checks on opensource.org

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -17,6 +17,9 @@
     },
     {
       "pattern": "^/images/"
+    },
+    {
+      "pattern": "^https://opensource.org/licenses/Apache-2.0$"
     }
   ]
 }


### PR DESCRIPTION
Our link to https://opensource.org/licenses/Apache-2.0 is consistently
failing Markdown link checks with a 503, but the page is available
when accessed *not* from a GHA.

This is outwith our control, ignore it.

Fixes: #785
Signed-off-by: Stephen Kitt <skitt@redhat.com>