### PR TITLE
Document ARM64 support

### DIFF
--- a/src/content/getting-started/_index.en.md
+++ b/src/content/getting-started/_index.en.md
@@ -48,6 +48,9 @@ directions. This is not a requirement when using OVN-Kubernetes CNI.
 the Gateway nodes so that other nodes in the cluster can access it. Also, no other workload on the Gateway nodes should be listening on TCP
 port 8080.
 * Worker node IPs on all connected clusters must be outside of the Pod/Service CIDR ranges.
+* Submariner can be deployed on x86-64 and ARM64 nodes.
+  (Submariner components are deployed on _all_ nodes in the cluster,
+  so all nodes must be x86-64 or ARM64.)
 
 An example of three clusters configured to use with Submariner (without Globalnet) would look like the following:
 


### PR DESCRIPTION
So far we haven't documented our architecture support anywhere;
mention that we support x86-64 and ARM64, and that all nodes in a
cluster must use a supported platform.

Fixes: #782
Signed-off-by: Stephen Kitt <skitt@redhat.com>