### PR TITLE
Drop references to shflags

### DIFF
--- a/src/content/development/building-testing/ci-maintenance/_index.en.md
+++ b/src/content/development/building-testing/ci-maintenance/_index.en.md
@@ -38,17 +38,6 @@ ENV LINT_VERSION=<version> \
 
 [`submariner-io/shipyard/package/Dockerfile.shipyard-dapper-base`](https://github.com/submariner-io/shipyard/blob/devel/package/Dockerfile.shipyard-dapper-base)
 
-## Shflags Library Version
-
-Shipyard uses the shflags library. Because it must be downloaded (if missing) and sourced at the start of Shipyard's shared scripts, the
-version is maintained in a special place and must be manually updated.
-
-```shell
-SHFLAGS_VERSION=${SHFLAGS_VERSION:=<version>}
-```
-
-[`submariner-io/shipyard/scripts/shared/lib/shflags`](https://github.com/submariner-io/shipyard/blob/devel/scripts/shared/lib/shflags)
-
 ## GitHub Actions
 
 All our projects use GitHub actions.


### PR DESCRIPTION
Since Shipyard commit 5ceb1af8149f ("Remove `shflags` entirely"), we
no longer use shflags. Drop our references to it.

This also fixes a broken link (`scripts/shared/lib/shflags` is gone).

Fixes: #812
Signed-off-by: Stephen Kitt <skitt@redhat.com>