### PR TITLE
subctl diagnose in cluster: add transient label

### DIFF
--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -555,6 +555,9 @@ metadata:
   namespace: submariner-operator
 spec:
   template:
+    metadata:
+      labels:
+        submariner.io/transient: "true"
     spec:
       containers:
       - name: submariner-diagnose


### PR DESCRIPTION
Depends on https://github.com/submariner-io/subctl/pull/183

Signed-off-by: Tomer Shefler <tshefler@carbonblack.com>