### PR TITLE
Stop documenting --ikeport

### DIFF
--- a/src/content/getting-started/quickstart/openshift/vsphere-aws/_index.md
+++ b/src/content/getting-started/quickstart/openshift/vsphere-aws/_index.md
@@ -117,11 +117,11 @@ subctl deploy-broker --kubeconfig cluster-b/auth/kubeconfig
 #### Join cluster-b (AWS) and cluster-a (vSphere) to the Broker
 
 ```bash
-subctl join --kubeconfig cluster-b/auth/kubeconfig broker-info.subm --ikeport 501 --nattport 4501
+subctl join --kubeconfig cluster-b/auth/kubeconfig broker-info.subm --nattport 4501
 ```
 
 ```bash
-subctl join --kubeconfig cluster-a/auth/kubeconfig broker-info.subm --ikeport 501 --nattport 4501
+subctl join --kubeconfig cluster-a/auth/kubeconfig broker-info.subm --nattport 4501
 ```
 
 {{< include "/resources/shared/verify_with_discovery.md" >}}

--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -136,7 +136,6 @@ deployment.
 | Flag                    | Description
 |:------------------------|:-----------------------------------------------|
 | `--natt`                | Enable NAT for IPsec (default enabled)
-| `--ikeport` `<value>`   | IPsec IKE port (default 500)
 | `--ipsec-debug`         | Enable IPsec debugging (verbose logging)
 | `--nattport` `<value>`  | IPsec NAT-T port (default 4500)
 


### PR DESCRIPTION
--ikeport was deprecated in 0.13, stop referring to it in our
documentation.

Signed-off-by: Stephen Kitt <skitt@redhat.com>