### PR TITLE
Add Slowloris mitigation 0.13.1 release note

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -20,6 +20,7 @@ This is a bugfix release:
 * Remove hardcoded `workerNodeList` while querying image for GCP and RHOS cloud preparation steps.
 * Collect the output of `ovn-sbctl show` in `subctl gather`.
 * Bump x/text to address CVE-2021-38561.
+* Set `ReadHeaderTimeout` (new in Go 1.18) to mitigate potential Slowloris attacks.
 
 ## v0.13.0
 


### PR DESCRIPTION
This seems user-facing. Also good to highlight this type of attack.

PRs were merged in early August, after the 0.13.0 release on July 18th.

Relates-to: submariner-io/shipyard#900
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>