### PR TITLE
Fix E2E link, minor grammar fixes

### DIFF
--- a/src/content/development/shipyard/_index.en.md
+++ b/src/content/development/shipyard/_index.en.md
@@ -67,7 +67,8 @@ make deploy USING='globalnet lighthouse wireguard'
   * **`vxlan`**: Use the VXLAN cable driver when deploying the clusters.
   * **`wireguard`**: Use the WireGuard cable driver when deploying the clusters.
 * Testing:
-  * **`subctl-verify`**: Force [end to end tests](#e2e) to run with `subctl verify`, irrespective of any possible project specific tests.
+  * **`subctl-verify`**: Force [end-to-end tests](../building-testing#e2e) to run with `subctl verify`, irrespective of any possible
+    project-specific tests.
 
 ### How to Add Shipyard to a Project
 


### PR DESCRIPTION
This doesn't fail the broken link check linter because it doesn't return an HTTP error code, it just doesn't go to a real heading.

Depends on #831 
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>