### PR TITLE
Add issues:write permission to broken links GHA

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -12,6 +12,8 @@ jobs:
     name: Markdown Links (all files)
     if: github.repository_owner == 'submariner-io'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Check out the repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8


### PR DESCRIPTION
The issue reporting step of the Markdown broken link check GitHub Action is failing due to missing permissions.

> Error: Resource not accessible by integration

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>