### PR TITLE
Cloud prepare doesn't open metrics ports

### DIFF
--- a/src/content/getting-started/_index.en.md
+++ b/src/content/getting-started/_index.en.md
@@ -44,9 +44,6 @@ For clusters behind corporate firewalls that block the default ports, Submariner
 * Submariner uses UDP port 4800 to encapsulate Pod traffic from worker and master nodes to the Gateway nodes. This is required in order to
 preserve the source IP addresses of the Pods. Ensure that firewall configuration allows 4800/UDP across all nodes in the cluster in both
 directions. This is not a requirement when using OVN-Kubernetes CNI.
-* Submariner uses TCP port 8080 to export metrics on the Gateway nodes. Ensure that firewall configuration allows ingress 8080/TCP on
-the Gateway nodes so that other nodes in the cluster can access it. Also, no other workload on the Gateway nodes should be listening on TCP
-port 8080.
 * Worker node IPs on all connected clusters must be outside of the Pod/Service CIDR ranges.
 * Submariner can be deployed on x86-64 and ARM64 nodes.
   (Submariner components are deployed on _all_ nodes in the cluster,

--- a/src/content/operations/deployment/subctl/_index.en.md
+++ b/src/content/operations/deployment/subctl/_index.en.md
@@ -295,7 +295,6 @@ Below is a list of available sub-commands:
 | `kube-proxy-mode [flags]`  | checks if the kube-proxy mode is supported by Submariner  | `--namespace` `<string>`
 | `cni`                      | checks if the detected CNI network plugin is supported by Submariner
 | `firewall intra-cluster [flags]`   | checks if the firewall configuration allows traffic via intra-cluster Submariner VXLAN interface | `--validation-timeout` `<value>` , `--verbose`, `--namespace` `<string>`
-| `firewall metrics [flags]` | checks if the firewall configuration allows metrics to be accessed from the Gateway nodes | `--validation-timeout` `<value>` , `--verbose`, `--namespace` `<string>`
 | `firewall inter-cluster <localkubeconfig> <remotekubeconfig> [flags]`  | checks if the firewall configuration allows tunnels to be configured on the Gateway nodes | `--validation-timeout` `<value>`, `--verbose`, `--namespace` `<string>`
 | `all`                      | runs all diagnostic checks (except those requiring two kubecontexts) |  
 <!-- markdownlint-enable line-length -->
@@ -387,7 +386,6 @@ This command prepares an OpenShift installer-provisioned infrastructure (IPI) on
 | `--ocp-metadata` `<string>`      | OCP metadata.json file (or directory containing it) to read AWS infra ID and region from
 | `--profile` `<string>`           | AWS profile to use for credentials
 | `--region` `<string>`            | AWS region
-| `--metrics-ports` `<ints>`       | Metrics ports, comma-separated (default 8080,8081)
 | `--nat-discovery-port` `<int>`   | NAT discovery port (default 4490)
 | `--natt-port` `<int>`            | IPsec NAT Traversal port (default 4500)
 | `--vxlan-port` `<int>`           | Internal VXLAN port (default 4800). Not required when using OVN-Kubernetes CNI
@@ -408,7 +406,6 @@ This command prepares an OpenShift installer-provisioned infrastructure (IPI) on
 | `--ocp-metadata` `<string>`      | OCP metadata.json file (or directory containing it) to read GCP infra ID and region from
 | `--project-id` `<string>`        | GCP project ID
 | `--region` `<string>`            | GCP region
-| `--metrics-ports` `<ints>`       | Metrics ports, comma-separated (default 8080,8081)
 | `--nat-discovery-port` `<int>`   | NAT discovery port (default 4490)
 | `--natt-port` `<int>`            | IPsec NAT Traversal port (default 4500)
 | `--vxlan-port` `<int>`           | Internal VXLAN port (default 4800). Not required when using OVN-Kubernetes CNI
@@ -429,7 +426,6 @@ This command prepares an OpenShift installer-provisioned infrastructure (IPI) on
 | `--ocp-metadata` `<string>`      | OCP metadata.json file (or directory containing it) to read OpenStack infra ID and region from
 | `--project-id` `<string>`        | OpenStack project ID
 | `--region` `<string>`            | OpenStack region
-| `--metrics-ports` `<ints>`       | Metrics ports, comma-separated (default 8080,8081)
 | `--nat-discovery-port` `<int>`   | NAT discovery port (default 4490)
 | `--natt-port` `<int>`            | IPsec NAT Traversal port (default 4500)
 | `--vxlan-port` `<int>`           | Internal VXLAN port (default 4800). Not required when using OVN-Kubernetes CNI

--- a/src/content/operations/usage/_index.en.md
+++ b/src/content/operations/usage/_index.en.md
@@ -79,6 +79,7 @@ Pods, you can specify the `--watch` flag with the command:
 $ kubectl -n submariner-operator get pods
 NAME                                           READY   STATUS    RESTARTS   AGE
 submariner-gateway-btzrq                       1/1     Running   0          76s
+submariner-metrics-proxy-sznnc                 1/1     Running   0          76s
 submariner-lighthouse-agent-586cf4899-wn747    1/1     Running   0          75s
 submariner-lighthouse-coredns-c88f64f5-h77kw   1/1     Running   0          73s
 submariner-lighthouse-coredns-c88f64f5-qlw4x   1/1     Running   0          73s


### PR DESCRIPTION
As part of metrics proxy redesign, we no longer need to open ports 8080 and 8081 in the firewall as part of cloud prepare.

Refer https://github.com/submariner-io/enhancements/pull/128

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>