### PR TITLE
Fix Shipyard links

### DIFF
--- a/src/content/development/_index.en.md
+++ b/src/content/development/_index.en.md
@@ -18,8 +18,9 @@ pre = "<b>4. </b>"
   * [Security Reporting](security/reporting)
   * [Container Requirements](security/containers)
 * [Working with Shipyard](shipyard)
-  * [Adding Shipyard to a Project](shipyard/first-time)
-  * [Advanced Features](shipyard/advanced)
+  * [Customizing Deployments](shipyard/settings)
+  * [Shared Targets](shipyard/targets)
+  * [Image Related Targets](shipyard/images)
 
 ### Help Wanted
 

--- a/src/content/getting-started/quickstart/kind/_index.md
+++ b/src/content/getting-started/quickstart/kind/_index.md
@@ -37,7 +37,7 @@ See the [settings](https://github.com/submariner-io/submariner-operator/blob/dev
 Once you become familiar with Submariner's basics, you may want to visit the
 [Building and Testing page](../../../development/building-testing/) to learn more about customizing your Submariner development deployment.
 To understand how Submariner's development deployment infrastructure works under the hood, see
-[Submariner Deployment Customization in the Shipyard Advanced Options](../../../development/shipyard/advanced/).
+[Deployment Customization in the Shipyard documentation](../../../development/shipyard/settings/).
 
 ### Deploy Manually
 


### PR DESCRIPTION
Following commit 1b40e360bcc8 ("Overhaul Shipyard section"), a few links are broken; this updates those to their new locations and updates the table of contents for the Shipyard section.

Signed-off-by: Stephen Kitt <skitt@redhat.com>