### PR TITLE
Add HTTP and Flannel to MD capitalisation linting, fix issue

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -26,7 +26,9 @@ spelling:
     - Admiral
     - ClusterSet
     - Coastguard
+    - Flannel
     - Globalnet
+    - HTTP
     - IPsec
     - iptables
     - kind

--- a/src/content/operations/usage/_index.en.md
+++ b/src/content/operations/usage/_index.en.md
@@ -246,9 +246,9 @@ $ kubectl config use-context cluster3
 Switched to context "cluster3".
 ```
 
-The following commands create an `nginx` Service in the `nginx-test` namespace which targets TCP port 8080, with name http,
-on any Pod with the `app: nginx` label and exposes it on an abstracted Service port. When created, the Service is assigned
-a unique IP address (also called `ClusterIP`):
+The following commands create an `nginx` Service in the `nginx-test` namespace which targets TCP port 8080, with name `http`, on any Pod
+with the `app: nginx` label and exposes it on an abstracted Service port. When created, the Service is assigned a unique IP address (also
+called `ClusterIP`):
 
 ```bash
 $ kubectl create namespace nginx-test


### PR DESCRIPTION
Flannel upstream uses uppercase and lowercase sporadically, seemingly
without a consistent pattern. Lacking a standard from the project, let's
follow normal grammar and capitalize it as a proper noun.
    
HTTP should clearly be all-caps, but this does show up as an issue.
