### PR TITLE
Remove outdated statement about merged kubeconfigs

### DIFF
--- a/src/content/operations/troubleshooting/_index.en.md
+++ b/src/content/operations/troubleshooting/_index.en.md
@@ -44,10 +44,6 @@ Diagnose common firewall issues between a pair of clusters:
 subctl diagnose firewall inter-cluster <kubeconfig0 path> <kubeconfig1 path>
 ```
 
-{{% notice info %}}
-[Merged KUBECONFIGs are currently not supported by `subctl diagnose firewall`](https://github.com/open-cluster-management/backlog/issues/17196).
-{{% /notice %}}
-
 Collect details about an issue you'd like help with:
 
 ```shell


### PR DESCRIPTION
Merged kubeconfigs are now supported (https://github.com/submariner-io/enhancements/issues/79). 

Signed-off-by: nyechiel <nyechiel@redhat.com>