### PR TITLE
Keep release notes time-series, move 0.12.3 to top

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -4,6 +4,19 @@ title = "Releases"
 weight = 40
 +++
 <!-- markdownlint-disable no-duplicate-header -->
+## v0.12.3
+
+This is a bugfix release:
+
+* Image version hashes are now 12 character long, avoiding possible collisions between images.
+* Stop using cluster-owned tag for AWS cloud prepare, fixing problems with Submariner security groups left over after uninstallation.
+* Support overriding the MTU value used in TCP MSS clamping, allowing fine tuning of MTU when necessary.
+* CNI interface annotations created by Submariner are now removed during uninstallation.
+* Bump x/text to address CVE-2021-38561 and CVE-2022-32149.
+* Diagnose now validates if the `OVNKubernetes` CNI is supported by the deployed Submariner.
+* Set `DNSPolicy` to `ClusterFirstWithHostNet` for pods that run with host networking.
+* Service Discovery now writes the DNS message response body when it is not a `ServerFailure` to avoid unnecessary client retries.
+
 ## v0.14.1
 
 This is a bugfix release:
@@ -146,19 +159,6 @@ user-specified namespace is missing any of these labels, `subctl` will inform th
 * It is now possible to customize the default TCP MSS clamping value set by Submariner in Globalnet deployments. This could be useful in
 network topologies where MTU issues are seen. To force a particular MSS clamping value use the `submariner.io/tcp-clamp-mss` node annotation
 on Gateway nodes, e.g. `kubectl annotate node <node_name> submariner.io/tcp-clamp-mss=<value>`.
-
-## v0.12.3
-
-This is a bugfix release:
-
-* Image version hashes are now 12 character long, avoiding possible collisions between images.
-* Stop using cluster-owned tag for AWS cloud prepare, fixing problems with Submariner security groups left over after uninstallation.
-* Support overriding the MTU value used in TCP MSS clamping, allowing fine tuning of MTU when necessary.
-* CNI interface annotations created by Submariner are now removed during uninstallation.
-* Bump x/text to address CVE-2021-38561 and CVE-2022-32149.
-* Diagnose now validates if the `OVNKubernetes` CNI is supported by the deployed Submariner.
-* Set `DNSPolicy` to `ClusterFirstWithHostNet` for pods that run with host networking.
-* Service Discovery now writes the DNS message response body when it is not a `ServerFailure` to avoid unnecessary client retries.
 
 ## v0.12.2
 


### PR DESCRIPTION
We've so far kept the release notes in order by time, with the most recent ones at the top. The just-merged 0.12.3 release notes were added lower in the doc, near other 0.12 notes. Note that the 0.12.0-2 releases were in sequence, with no other releases in-between.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>