### PR TITLE
Fix broken links, HTML tags not supported

### DIFF
--- a/src/content/development/release-process/_index.en.md
+++ b/src/content/development/release-process/_index.en.md
@@ -119,7 +119,7 @@ After the first invocation, the command needs to be run on branches based on the
 {{% /notice %}}
 
 Once there isn't anything else to do, the command will inform you. At this point, continue manually with any steps not automated yet,
-starting with [Verify Release](#verify).
+starting with [Verify Release](#step-5-verify-release).
 
 ## Manual Release Creation Process
 
@@ -308,7 +308,7 @@ Once the `submariner-operator` and `submariner-charts` releases are complete, we
    unpin the Shipyard Dapper base image version, that is set it back to `devel`. For ongoing development we want each project to
    automatically pick up the latest changes to the base image.
 
-### Step 5: Verify Release <a id="verify"></a>
+### Step 5: Verify Release
 
 You can follow any of the [quick start guides](../../getting-started/quickstart).
 

--- a/src/content/development/shipyard/targets/_index.en.md
+++ b/src/content/development/shipyard/targets/_index.en.md
@@ -8,7 +8,7 @@ Shipyard ships a [Makefile.inc] file which defines these basic targets:
 
 * **[clusters](#clusters):** Creates the kind-based cluster environment.
 * **[deploy](#deploy)** : Deploys Submariner components in the cluster environment (depends on clusters).
-* **[e2e](#e2e)** : Runs end to end tests on top of the deployed environment (deploying it if necessary).
+* **[e2e](#e2e-end-to-end)** : Runs end to end tests on top of the deployed environment (deploying it if necessary).
 * **[clean-clusters](#clean-clusters):** Deletes the kind environment (if it exists) and any residual resources.
 * **[clean-generated](#clean-generated):** Deletes all generated files.
 * **[clean](#clean):** Cleans everything up (running clusters and generated files).
@@ -58,7 +58,7 @@ make deploy
 * **`DEPLOYTOOL`**: The tool used to deploy Submariner itself (defaults to `operator`).
 * **`LIGHTHOUSE`**: Deploys Lighthouse in addition to the basic Submariner deployment (defaults to `false`).
 
-### E2E (End to End) <a id="e2e"></a>
+### E2E (End to End)
 
 Runs end to end testing on the deployed environment (if one isn't created yet, this target will first invoke the `deploy` target to do so).
 The tests are taken from the project, unless it has no specific end to end tests, in which case generic testing using `subctl verify` is


### PR DESCRIPTION
It seems that HTML anchor tags on headers are no longer supported by our link checking linter. Remove the anchor tags and use headings.

To link to headings with complex symbols, just ignore the symbols.

Closes: #862
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>