### PR TITLE
Fix OpenShift on GCP Prerequisites

### DIFF
--- a/src/resources/shared/openshift/setup_openshift_gcp.md
+++ b/src/resources/shared/openshift/setup_openshift_gcp.md
@@ -3,5 +3,5 @@
 Before we begin, the following tools need to be downloaded and added to your `$PATH`:
 
 1. **OpenShift installer**, **pull secret**, and **command line interface**. All can be downloaded from
-   [here](https://cloud.redhat.com/openshift/install/aws/installer-provisioned).
-2. **GCP CLI** which can be downloaded from [here](https://cloud.google.com/sdk/gcloud).
+   [the official Installer documenation](https://console.redhat.com/openshift/install/gcp/installer-provisioned).
+2. **GCP CLI** which can be downloaded from [the official GCP documenation](https://cloud.google.com/sdk/gcloud).


### PR DESCRIPTION
Links are now properly pointing to GCP and not AWS docs.

Signed-off-by: nyechiel <nyechiel@redhat.com>