### PR TITLE
Run dependent issues check less frequently

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -2,22 +2,8 @@
 name: PR Dependencies
 
 on:
-  issues:
-    types:
-      - opened
-      - edited
-      - closed
-      - reopened
-      - synchronize
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - closed
-      - reopened
-      - synchronize
   schedule:
-    - cron: '0 0/6 * * *'  # every 6 hours
+    - cron: '0 1 * * *' # Once a day at 1AM
 
 permissions:
   issues: write


### PR DESCRIPTION
The `Check Dependency` job is failing  with:

> SHA and context has reached the maximum number of statuses

This is likely due to the amount activity relative to the number of commits. Lessening the job frequency should help. This commit will also make a new SHA, which should fix the issue.