### PR TITLE
Run dependent issues check only on open/edit

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -16,8 +16,6 @@ on:
       - closed
       - reopened
       - synchronize
-  schedule:
-    - cron: '0 0/6 * * *'  # every 6 hours
 
 permissions:
   issues: write


### PR DESCRIPTION
The `Check Dependency` job is failing  with:

> SHA and context has reached the maximum number of statuses

This is likely due to the amount activity relative to the number of commits. Lessen the job frequency to only run an open/edit instead of daily. This commit will also make a new SHA, which should fix the issue.