### PR TITLE
Add website style guidelines for release notes

### DIFF
--- a/src/content/development/website/style-guide/_index.en.md
+++ b/src/content/development/website/style-guide/_index.en.md
@@ -59,3 +59,9 @@ Avoid referring to things as "new", as this will become out of date and require 
 Instead, document the versions that introduce or remove features:
 
 > As of 0.12.0, a `subctl` image is provided ...
+
+### Release Notes Formatting
+
+Follow the [Kubernetes guidelines for writing good release notes](https://www.k8s.dev/docs/guide/release-notes/#writing-good-release-notes).
+
+In particular, note that release notes should be written in past tense.


### PR DESCRIPTION
Link to the upstream K8s guidelines we should follow.

Clarify that release notes should be in past tense. This will require refactoring the current release notes.