### PR TITLE
Allow PRs to target release note branches

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -11,6 +11,6 @@ jobs:
     name: PR targets branch
     runs-on: ubuntu-latest
     steps:
-      - name: Check that the PR targets devel
-        if: ${{ github.base_ref != 'devel' }}
+      - name: Check that the PR targets devel or a release note branch
+        if: ${{ github.base_ref != 'devel' && !startsWith(github.base_ref, 'release-notes-') }}
         run: exit 1


### PR DESCRIPTION
Now that we're preparing release notes on branches, we need to allow PRs to target those branches.