### PR TITLE
Fix PR targets branch GHA

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -12,5 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check that the PR targets devel or a release note branch
-        if: ${{ github.base_ref != 'devel' && !startsWith(github.base_ref, 'release-notes-') }}
+        if: ${{ github.base_ref != 'devel' && !startsWith(github.base_ref, 'release-notes') }}
         run: exit 1


### PR DESCRIPTION
The release note branches start with "release-notes" w/o the dash.