### PR TITLE
Check that PRs based on this branch target the branch (0.13)

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -11,6 +11,6 @@ jobs:
     name: PR targets branch
     runs-on: ubuntu-latest
     steps:
-      - name: Check that the PR targets devel
-        if: ${{ github.base_ref != 'devel' }}
+      - name: Check that the PR targets the correct branch
+        if: ${{ github.base_ref != 'release-notes-0.13' }}
         run: exit 1


### PR DESCRIPTION
Since https://github.com/submariner-io/submariner-website/pull/947, the main branch allows PRs targeting devel or release-note branches, and any newly-created release-note branch will default to that. However, once they're created, release-note branches should enforce PRs only targeting their branch.