### PR TITLE
Ignore link checks to SubM's Twitter

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -13,7 +13,7 @@
       "pattern": "^http://localhost:"
     },
     {
-      "pattern": "^https://twitter.com/submarinerio/status/[0-9]+"
+      "pattern": "^https://twitter.com/submarinerio"
     },
     {
       "pattern": "^/images/"


### PR DESCRIPTION
Ignore all link checks for Submariner's main Twitter homepage, as well as the already-ignored statuses.

Twitter has implemented some anti-bot that is causing CI to fail.

Fixes: #933