### PR TITLE
Add release notes for subctl#808

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -11,6 +11,7 @@ weight = 40
   environment which may forbid certain configurations in a disconnected Azure installation.
 * Submariner now uses case-insensitive comparison while parsing CNI names.
 * `subctl` is now built for ARM Macs (Darwin arm64).
+* `subctl show versions` now shows the versions of the metrics proxy and plugin syncer components.
 
 ## v0.14.5
 


### PR DESCRIPTION
subctl show versions now shows the versions of the metrics proxy and plugin syncer components.