### PR TITLE
Add release notes for subctl#810

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -10,6 +10,7 @@ weight = 40
 * The `subctl cloud prepare azure` command has a new flag, `air-gapped`, to indicate the cluster is in an air-gapped
   environment which may forbid certain configurations in a disconnected Azure installation.
 * Submariner now uses case-insensitive comparison while parsing CNI names.
+* `subctl` is now built for ARM Macs (Darwin arm64).
 
 ## v0.14.5
 


### PR DESCRIPTION
subctl is now built for ARM Macs (Darwin arm64).