### PR TITLE
Add release notes for subctl#811

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -9,6 +9,7 @@ weight = 40
 
 * The `subctl cloud prepare azure` command has a new flag, `air-gapped`, to indicate the cluster is in an air-gapped
   environment which may forbid certain configurations in a disconnected Azure installation.
+* `subctl` is now built for ARM Macs (Darwin arm64).
 
 ## v0.14.5
 


### PR DESCRIPTION
subctl is now built for ARM Macs (Darwin arm64).