### PR TITLE
Add release notes for submariner#2532

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -12,6 +12,7 @@ weight = 40
 * Submariner now uses case-insensitive comparison while parsing CNI names.
 * `subctl` is now built for ARM Macs (Darwin arm64).
 * `subctl show versions` now shows the versions of the metrics proxy and plugin syncer components.
+* The Globalnet component now handles out-of-order remote endpoint notifications properly.
 
 ## v0.14.5
 


### PR DESCRIPTION
Submariner now handles out-of-order remote endpoint notifications properly in Globalnet component.

Related to: https://github.com/submariner-io/submariner/pull/2536
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>