### PR TITLE
Add release notes for submariner#2504

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -10,6 +10,8 @@ weight = 40
 * The `subctl cloud prepare azure` command has a new flag, `air-gapped`, to indicate the cluster is in an air-gapped
   environment which may forbid certain configurations in a disconnected Azure installation.
 * Submariner now uses case-insensitive comparison while parsing CNI names.
+* Submariner gateway pods now skip invoking cable engine cleanup during termination, as this is handled by the route agent
+  during gateway migration.
 * `subctl` is now built for ARM Macs (Darwin arm64).
 * `subctl show versions` now shows the versions of the metrics proxy and plugin syncer components.
 


### PR DESCRIPTION
Submariner Gateway pod now skips invoking cableEngine cleanup during termination, as this is handled by the Route agent during gateway migration.

Related to: https://github.com/submariner-io/submariner/pull/2504
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>