### PR TITLE
Add release notes for submariner#2518

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -13,6 +13,8 @@ weight = 40
 * `subctl` is now built for ARM Macs (Darwin arm64).
 * Fixed an issue with OVNKubernetes CNI where routes could be accidentally deleted during cluster restart, or
   upgrade scenarios.
+* Submariner gateway pods now skip invoking cable engine cleanup during termination, as this is handled by the route agent
+  during gateway migration.
 
 ## v0.14.5
 


### PR DESCRIPTION
Submariner Gateway pod now skips invoking cableEngine cleanup during termination, as this is handled by the Route agent during gateway migration.

Related to: submariner-io/submariner#2518
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>