### PR TITLE
Add release notes for couple of PRs

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -14,6 +14,12 @@ weight = 40
 * Reduced data path downtime with Libreswan cable driver when gateway pod restarts.
 * Fixed an issue with OVNKubernetes CNI where routes could be accidentally deleted during cluster restart, or
   upgrade scenarios.
+* Submariner now uses case-insensitive comparison while parsing CNI names.
+* The `subctl gather` command now collects metrics proxy pod logs in Globalnet deployments.
+* Submariner gateway pods now skip invoking cable engine cleanup during termination, as this is handled by the route agent
+  during gateway migration.
+* Fixed issue which caused the IPsec pluto process to crash when the remote endpoint was unstable.
+* The Globalnet component now handles out-of-order remote endpoint notifications properly.
 
 ## v0.14.5
 


### PR DESCRIPTION
Includes the release notes for the following fixes.

* Submariner now uses case-insensitive comparison while parsing CNI names.
* subctl gather now collects Metrics proxy pod logs in a Globalnet deployment.
* Submariner Gateway pod now skips invoking cableEngine cleanup during termination, as this is handled by the Route agent during gateway migration.
* Fixed issue which caused the IPsec pluto process to crash when the remote endpoint was unstable.
* Submariner now handles out-of-order remote endpoint notifications properly in Globalnet component.

Related to: https://github.com/submariner-io/submariner/pull/2486
Related to: https://github.com/submariner-io/subctl/pull/770
Related to: https://github.com/submariner-io/submariner/pull/2499
Related to: https://github.com/submariner-io/submariner/pull/2517
Related to: https://github.com/submariner-io/submariner/pull/2532
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>