### PR TITLE
Accurately describe review approval requirements

### DIFF
--- a/src/content/development/code-review/_index.en.md
+++ b/src/content/development/code-review/_index.en.md
@@ -11,10 +11,10 @@ This guide is meant to facilitate Submariner code review by sharing norms, best 
 Submariner follows the [Kubernetes Code Review Guide][kube code review guide] wherever relevant. This guide collects the most important
 highlights of the Kubernetes process and adds Submariner-specific extensions.
 
-### Two non-author Committer approvals required
+### Two non-author approvals required
 
-Pull Requests to Submariner require two approvals from a Committer to the relevant part of the code base, as defined by the CODEOWNERS file
-at the root of each repository and the [Community
+Pull Requests to Submariner require two approvals, including at least one from a Committer to the relevant part of the code base,
+as defined by the CODEOWNERS file at the root of each repository and the [Community
 Membership/Committers](../../community/contributor-roles/#committers) process.
 
 ### No merge commits
@@ -85,7 +85,7 @@ approval (0/+1 vote) before the PR is merged.
 ### Update branch only after required reviews
 
 To avoid wasting resources by running unnecessary jobs, only use the **Update branch** button to add a merge commit once a PR is actually
-ready to merge (has [required reviews](#two-non-author-committer-approvals-required) and [no -1s](#address-all--1s-before-merging)). Unless
+ready to merge (has [required reviews](#two-non-author-approvals-required) and [no -1s](#address-all--1s-before-merging)). Unless
 other relevant code has changed, the new job results don't tell us anything new. Since changes are constantly being merged, it's likely
 another merge commit and set of jobs will be necessary right before merging anyway.
 


### PR DESCRIPTION
Submariner repositories are set up so that two approvals are required before a PR can be merged, but only one code owner approval is required. The built-in GitHub branch protection features only allow specifying that one code owner approval is required, they don't support specifying a minimum number of code owner approvals.