### PR TITLE
Add clustercidr arg to subctl join command for the k3s quick start

### DIFF
--- a/src/content/getting-started/quickstart/k3s/_index.md
+++ b/src/content/getting-started/quickstart/k3s/_index.md
@@ -93,13 +93,13 @@ subctl deploy-broker --kubeconfig kubeconfig.cluster-a
 #### Join cluster-a to the Broker
 
 ```bash
-subctl join --kubeconfig kubeconfig.cluster-a broker-info.subm --clusterid cluster-a --natt=false
+subctl join --kubeconfig kubeconfig.cluster-a broker-info.subm --clusterid cluster-a --natt=false --clustercidr 10.44.0.0/16
 ```
 
 #### Join cluster-b to the Broker
 
 ```bash
-subctl join --kubeconfig kubeconfig.cluster-b broker-info.subm --clusterid cluster-b --natt=false
+subctl join --kubeconfig kubeconfig.cluster-b broker-info.subm --clusterid cluster-b --natt=false --clustercidr 10.144.0.0/16
 ```
 
 ### Verify Deployment


### PR DESCRIPTION
There are a few issues which point out a problem with ClusterCIDR discoverability when using the K3s quick start (https://github.com/submariner-io/submariner/issues/1583, https://github.com/submariner-io/subctl/issues/444, https://github.com/submariner-io/submariner/issues/2128).

A workaround for this is to manually specify the ClusterCIDR when using the `join` command.