### PR TITLE
Update minimal versions

### DIFF
--- a/src/content/getting-started/_index.en.md
+++ b/src/content/getting-started/_index.en.md
@@ -31,8 +31,8 @@ Submariner has a few requirements to get started:
 
 * At least two Kubernetes clusters, one of which is designated to serve as the central Broker that is accessible by all of your connected
 clusters; this can be one of your connected clusters, or a dedicated cluster.
-* The oldest [tested Kubernetes version](../development/building-testing/ci-maintenance/#kubernetes-versions) is 1.17.
-  Older versions are known not to work with Submariner.
+* The oldest [tested Kubernetes version](../development/building-testing/ci-maintenance/#kubernetes-versions) is 1.19.
+  Older versions are known not to work with Submariner. Service discovery requires Kubernetes 1.21 or later.
 * Non-overlapping Pod and Service CIDRs between clusters. This is to prevent routing conflicts. For cases where addresses **do
 overlap**, [Globalnet](./architecture/globalnet) can be set up.
 * IP reachability between the gateway nodes. When connecting two clusters, the gateways must have at least one-way connectivity

--- a/src/content/operations/known-issues/_index.en.md
+++ b/src/content/operations/known-issues/_index.en.md
@@ -6,7 +6,7 @@ weight = 40
 
 ## General
 
-* Minimum supported Kubernetes version is 1.17.
+* Minimum supported Kubernetes version is 1.19 (1.21 for service discovery).
 * Submariner only supports kube-proxy in iptables mode. IPVS is not supported at this time.
 * CoreDNS is supported out of the box for `*.clusterset.local` service discovery. KubeDNS needs manual configuration. Please refer to the
 [GKE Quickstart Guide](../../getting-started/quickstart/managed-kubernetes/gke/#final-workaround-for-kubedns) for more information.


### PR DESCRIPTION
The lowest version against which Submariner is tested is now 1.19, and service discovery requires 1.21 or later.

Fixes: https://github.com/submariner-io/lighthouse/issues/1357