### PR TITLE
Skip the Internet Archive in broken link checks

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -20,6 +20,9 @@
     },
     {
       "pattern": "^https://opensource.org/licenses/Apache-2.0$"
+    },
+    {
+      "pattern": "^https://web.archive.org/web/"
     }
   ]
 }


### PR DESCRIPTION
We should not test Wayback Machine links for a number of reasons:

* They should never change. If they work, they should keep working.
* They slow down the tests or fail ("Status: 0").
* We shouldn't stress the nonprofit's infrastructure.

Relates-to: #1031