### PR TITLE
Update oldest K8s versions for Submariner

### DIFF
--- a/src/content/operations/known-issues/_index.en.md
+++ b/src/content/operations/known-issues/_index.en.md
@@ -6,7 +6,7 @@ weight = 40
 
 ## General
 
-* Minimum supported Kubernetes version is 1.19 (1.21 for service discovery).
+* The oldest Kubernetes version for which Submariner is known to work is 1.19 (1.21 for Service Discovery).
 * Submariner only supports kube-proxy in iptables mode. IPVS is not supported at this time.
 * CoreDNS is supported out of the box for `*.clusterset.local` service discovery. KubeDNS needs manual configuration. Please refer to the
 [GKE Quickstart Guide](../../getting-started/quickstart/managed-kubernetes/gke/#final-workaround-for-kubedns) for more information.


### PR DESCRIPTION
Also change the verbiage to "oldest working version".