### PR TITLE
Base image software maintenance only before 0.16

### DIFF
--- a/src/content/development/building-testing/ci-maintenance/_index.en.md
+++ b/src/content/development/building-testing/ci-maintenance/_index.en.md
@@ -76,7 +76,7 @@ Unsupported Kubernetes Cut-off | Oldest working version | One defaults-only E2E 
 
 ## Shipyard Base Image Software
 
-Some versions of software used by the Shipyard base image are maintained manually and should be periodically updated.
+In branches older than 0.16, some versions of software used by the Shipyard base image are maintained manually and should be periodically updated.
 
 ```shell
 ENV LINT_VERSION=<version> \


### PR DESCRIPTION
Since 0.16.0, versions of components used in the base image are tracked using tools/go.mod and updated by dependabot.