### PR TITLE
Add 0.18 release notes for subctl PR #1099

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -11,6 +11,7 @@ weight = 40
 
 * `subctl join` and other commands now support HTTP proxy arguments corresponding to the HTTP proxy environment variables
    that are propagated to the various pods.
+* `subctl verify` now outputs a short description of each test that is run.
 
 ### Other changes
 


### PR DESCRIPTION
Release notes for https://github.com/submariner-io/subctl/pull/1099