### PR TITLE
Merge release notes for 0.16.5

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -5,7 +5,7 @@ weight = 40
 +++
 <!-- markdownlint-disable no-duplicate-header -->
 
-## v0.16.4 (May 10, 2024)
+## v0.16.4/v0.16.5 (May 23, 2024)
 
 * Fixed an issue in Service Discovery where un-exporting a Service on one cluster and then quickly exporting it on another cluster could
   result in a missing `ServiceImport` resource and cause name resolution failures.


### PR DESCRIPTION
Since 0.16.5 fixes issues with 0.16.4, update the 0.16.4 section to include 0.16.5.