### PR TITLE
Add 0.17 release note for PR  cloud-prepare #1014

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -14,6 +14,7 @@ weight = 40
   RFC1035 and RFC2181.
 * Fixed an issue with Service Discovery that caused a new `EndpointSlice` to be created when the labels on the exporting `Service`
   were updated.
+* New options were added to `subctl cloud prepare` to support a custom vpc for AWS.
 
 ## v0.17.2
 


### PR DESCRIPTION
Add 0.17 release note for PR submariner-io/cloud-prepare#1014