### PR TITLE
Add release note for enhanced flannel network discovery

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -11,6 +11,8 @@ weight = 40
 
 ### Other changes
 
+* Enhanced the Flannel network discovery logic to improve performance and reliability.
+
 ## v0.18.2 (October 30, 2024)
 
 * Fixed an issue with Service Discovery that caused a new `EndpointSlice` to be created when the labels on the exporting `Service`


### PR DESCRIPTION
This PR adds a release note entry for the recent enhancement made to the Flannel network discovery improvements. The release note is intended to inform the community about the change and ensure it is included in the upcoming v0.20.0 release documentation.  
