### PR TITLE
Ignore static.sched.com PDFs in link checker

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -26,6 +26,9 @@
     },
     {
       "pattern": "^https://doi.org/"
+    },
+    {
+      "pattern": "^https://static.sched.com/hosted_files/"
     }
   ]
 }


### PR DESCRIPTION
These PDFs return 403 errors but are still accessible via browser.

Fixes: #1284