### PR TITLE
Add documentation for TCP MSS clamping customization

### DIFF
--- a/src/content/getting-started/architecture/gateway-engine/_index.en.md
+++ b/src/content/getting-started/architecture/gateway-engine/_index.en.md
@@ -92,6 +92,20 @@ a second cluster) when Submariner is used.
 ![Figure 3 - Clusters inter-connected using VXLAN tunnels](/images/cable-drivers/vxlan_cable.png)
 <!-- Image Source (draw.io): src/static/images/cable-drivers/cable_driver_networking.drawio -->
 
+#### Customize TCP MSS Clamping
+
+In network topologies where MTU issues are observed, the encapsulation overhead added by Submariner can cause packet drops.
+To resolve this, you can force a specific MSS clamping value by adding an annotation to the Gateway nodes,
+which instructs Submariner to rewrite the TCP Maximum Segment Size.
+
+Use the following commands to apply the configuration and restart the route-agent pods to pick up the change:
+
+```bash
+kubectl annotate node <gw_node_name> submariner.io/tcp-clamp-mss=<value>
+
+kubectl delete pod -n submariner-operator -l app=submariner-routeagent
+```
+
 ### Gateway Failover
 
 If the active Gateway Engine fails, another Gateway Engine on one of the


### PR DESCRIPTION
Add a new section under Cable Drivers Topology Overview explaining how to customize TCP MSS clamping to resolve MTU issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on customizing TCP MSS Clamping for VXLAN networks, including configuration steps and pod restart procedures.
  * Enhanced Gateway Failover documentation with detailed explanations of leadership behavior, reconciliation processes, and cross-cluster communication mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->