### PR TITLE
Add 0.23 release note for various PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         run: make static-all
 
       - name: Upload proposed static website for review
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: Proposed static website
           path: output

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
         with:
           days-before-issue-stale: 120
           days-before-pr-stale: 14

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -11,6 +11,12 @@ weight = 40
 
 ### Other changes
 
+## v0.23.0
+
+### New features
+
+### Other changes
+
 ## v0.22.0 (December 8, 2025)
 
 ### New features

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -11,7 +11,7 @@ weight = 40
 
 ### Other changes
 
-## v0.22.0
+## v0.22.0 (December 8, 2025)
 
 ### New features
 

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -12,6 +12,7 @@ weight = 40
 ### Other changes
 
 * Azure cloud prepare now validates zones against the region when selecting availability zones for Submariner gateways.
+* RHOS cloud prepare now supports custom subnet names via the `--subnet-names` flag for gateway deployment.
 * Submariner Helm charts now allow broker credentials and the IPsec PSK to be specified as Kubernetes Secrets.
 
 ## v0.23.0

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -11,6 +11,8 @@ weight = 40
 
 ### Other changes
 
+* Submariner Helm charts now allow broker credentials and the IPsec PSK to be specified as Kubernetes Secrets.
+
 ## v0.23.0
 
 ### New features

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -11,6 +11,7 @@ weight = 40
 
 ### Other changes
 
+* Azure cloud prepare now validates zones against the region when selecting availability zones for Submariner gateways.
 * Submariner Helm charts now allow broker credentials and the IPsec PSK to be specified as Kubernetes Secrets.
 
 ## v0.23.0

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -11,6 +11,7 @@ weight = 40
 
 ### Other changes
 
+* AWS cloud prepare now adds Kubernetes cluster tags to security groups to comply with LoadBalancer security group restrictions.
 * Azure cloud prepare now validates zones against the region when selecting availability zones for Submariner gateways.
 * RHOS cloud prepare now supports custom subnet names via the `--subnet-names` flag for gateway deployment.
 * Submariner Helm charts now allow broker credentials and the IPsec PSK to be specified as Kubernetes Secrets.


### PR DESCRIPTION
See commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS cloud prepare adds Kubernetes cluster tags to security groups
  * Azure cloud prepare validates availability zones for the selected region
  * RHOS cloud prepare supports custom subnet names via flag
  * Helm charts allow broker credentials and IPsec PSK to be stored as Kubernetes Secrets
  * Submariner chart/config updates and other v0.23.0 enhancements

* **Bug Fixes**
  * Fixed Libreswan encapsulation flag for versions prior to 5.0
  * General dependency security fixes

* **Chores**
  * Updated CI workflow action revisions in GitHub Actions configurations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->