### PR TITLE
Add AWS VPC CNI known issue

### DIFF
--- a/src/content/operations/known-issues/_index.en.md
+++ b/src/content/operations/known-issues/_index.en.md
@@ -34,3 +34,20 @@ oc adm policy add-scc-to-user privileged system:serviceaccount:submariner:submar
 ```
 
 This is handled automatically in `subctl` and the Submariner addon.
+
+## AWS EKS with AWS VPC CNI: Intermittent Connectivity on Secondary ENIs
+
+When using Submariner on AWS EKS with the default AWS VPC CNI configuration, pods assigned to secondary Elastic Network Interfaces (ENIs)
+may experience cross-cluster connectivity loss.
+
+The AWS VPC CNI for pods on secondary ENIs creates IP rules that force traffic into a custom routing table instead of the main table.
+Currently, the Submariner route-agent only populates the main routing table. Consequently, these custom tables lack the routes to the
+`vx-submariner` interface, and traffic is instead sent to the default VPC gateway (black-holed).
+
+You can manually replicate the Submariner routes from the main table into the custom tables created by the CNI. For example,
+if your pod is using table 2:
+
+```shell
+sudo ip route add <remote-cluster-cidr> via <submariner-gw-ip> dev vx-submariner table 2
+sudo ip route add <submariner-internal-cidr> dev vx-submariner table 2
+```


### PR DESCRIPTION
Document intermittent connectivity issues with Submariner on AWS EKS using secondary ENIs and provide manual routing instructions.

According to https://github.com/submariner-io/submariner/issues/3697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for AWS EKS deployments using Submariner with AWS VPC CNI. Describes known connectivity issues affecting secondary Elastic Network Interfaces (ENIs) due to custom routing table synchronization gaps. Includes detailed explanation of the root cause and provides manual workaround commands to synchronize routes and restore proper network traffic flow between clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->