### PR TITLE
Merge release notes for 0.23 .1

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -11,6 +11,8 @@ weight = 40
 
 ### Other changes
 
+* Submariner Helm charts now allow broker credentials and the IPsec PSK to be specified as Kubernetes Secrets.
+
 ## v0.22.1 (February 10, 2026)
 
 * AWS cloud prepare now adds Kubernetes cluster tags to security groups to comply with LoadBalancer security group restrictions.

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -5,6 +5,12 @@ weight = 40
 +++
 <!-- markdownlint-disable no-duplicate-heading -->
 
+## v0.23.0
+
+### New features
+
+### Other changes
+
 ## v0.22.1 (February 10, 2026)
 
 * AWS cloud prepare now adds Kubernetes cluster tags to security groups to comply with LoadBalancer security group restrictions.

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -5,11 +5,7 @@ weight = 40
 +++
 <!-- markdownlint-disable no-duplicate-heading -->
 
-## v0.23.0
-
-### New features
-
-### Other changes
+## v0.23.1 (March 12, 2026)
 
 * AWS cloud prepare now adds Kubernetes cluster tags to security groups to comply with LoadBalancer security group restrictions.
 * Azure cloud prepare now validates zones against the region when selecting availability zones for Submariner gateways.

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -11,6 +11,7 @@ weight = 40
 
 ### Other changes
 
+* Azure cloud prepare now validates zones against the region when selecting availability zones for Submariner gateways.
 * Submariner Helm charts now allow broker credentials and the IPsec PSK to be specified as Kubernetes Secrets.
 
 ## v0.22.1 (February 10, 2026)

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -12,6 +12,7 @@ weight = 40
 ### Other changes
 
 * Azure cloud prepare now validates zones against the region when selecting availability zones for Submariner gateways.
+* RHOS cloud prepare now supports custom subnet names via the `--subnet-names` flag for gateway deployment.
 * Submariner Helm charts now allow broker credentials and the IPsec PSK to be specified as Kubernetes Secrets.
 
 ## v0.22.1 (February 10, 2026)

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -11,6 +11,7 @@ weight = 40
 
 ### Other changes
 
+* AWS cloud prepare now adds Kubernetes cluster tags to security groups to comply with LoadBalancer security group restrictions.
 * Azure cloud prepare now validates zones against the region when selecting availability zones for Submariner gateways.
 * RHOS cloud prepare now supports custom subnet names via the `--subnet-names` flag for gateway deployment.
 * Submariner Helm charts now allow broker credentials and the IPsec PSK to be specified as Kubernetes Secrets.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v0.23.1 (March 12, 2026) documenting updates to AWS, Azure, and RHOS cloud prepares, and Submariner Helm charts functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->