### PR TITLE
Note that 0.23.1 replaces 0.23.0

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -12,6 +12,8 @@ weight = 40
 * RHOS cloud prepare now supports custom subnet names via the `--subnet-names` flag for gateway deployment.
 * Submariner Helm charts now allow broker credentials and the IPsec PSK to be specified as Kubernetes Secrets.
 
+**Note**: this version replaces v0.23.0.
+
 ## v0.22.1 (February 10, 2026)
 
 * AWS cloud prepare now adds Kubernetes cluster tags to security groups to comply with LoadBalancer security group restrictions.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a clarification note to the v0.23.1 release documentation indicating that v0.23.1 completely replaces v0.23.0, superseding the previous version entirely. This ensures users understand the version relationship clearly and have the information needed to make informed decisions about when to upgrade from v0.23.0 to v0.23.1 to obtain the latest stable version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->