### PR TITLE
Add 0.22.2 release note for submariner-io/submariner/pull/3914

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -5,6 +5,10 @@ weight = 40
 +++
 <!-- markdownlint-disable no-duplicate-heading -->
 
+## v0.22.2
+
+* Fixed potential scenarios where multiple gateway pods could have their active status label set incorrectly.
+
 ## v0.22.0
 
 ### New features


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where multiple gateway pods could incorrectly have their active status label assigned simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->