### PR TITLE
Fix publish workflow to only build current branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - devel
-      - 'release-*'
 
 permissions: {}
 
@@ -33,8 +32,8 @@ jobs:
         env:
           GIT_DEPLOY_KEY: ${{ secrets.GIT_DEPLOY_KEY }}
 
-      - name: Build the website static files for each release
-        run: make static-all
+      - name: Build the website static files
+        run: make static
 
       - name: Push the updated static files
         run: ./scripts/publish


### PR DESCRIPTION
The publish workflow was still using `make static-all` which attempts to build all release branches. This fails because different branches require different Hugo versions and themes (old branches use hugo-theme-learn while devel now uses hugo-theme-relearn).

This change mirrors the fix in f01c92a which updated build.yml to use `make static` instead. Additionally, the workflow now only triggers on the devel branch since release branches don't get a site published anyway, and running publish from a release branch would only publish that branch's content, which would be incomplete.

Fixes the publish job failure after PR #1322 was merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to trigger only on the development branch (removed other push branch filters).
  * Build step simplified to run a streamlined static build command instead of the previous full static-all build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->