### PR TITLE
Add 0.21 release note for submariner-io/cloud-prepare/pull/1335

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -7,6 +7,7 @@ weight = 40
 
 ## v0.21.2
 
+* Azure cloud prepare now supports Marketplace-based images for gateway MachineSet creation on ARO-style clusters.
 * The Libreswan cable driver now uses the correct encapsulation option for `ipsec whack` versions < 5.0.
 
 ## v0.21.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes for v0.21.2 to document support for Marketplace-based images in `subctl cloud prepare azure` for ARO-style clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->