### PR TITLE
docs(quickstart): reference KubeStellar Console guided install mission

### DIFF
--- a/src/content/getting-started/quickstart/_index.en.md
+++ b/src/content/getting-started/quickstart/_index.en.md
@@ -15,3 +15,6 @@ weight = 20
   * [On GCP](openshift/gcp-lb)
   * [Hybrid vSphere and AWS](openshift/vsphere-aws)
 * [External Network (Experimental)](external)
+* Community-maintained guided install:
+  * [KubeStellar Console — Submariner Install Mission](https://console.kubestellar.io/missions/install-submariner) —
+    wraps the current `subctl` workflow (deploy-broker, join, verify, cross-cluster connectivity test) in a guided UI


### PR DESCRIPTION
## Summary
- Adds a community-maintained entry under **Quickstart Guides** pointing to the [KubeStellar Console Submariner install mission](https://console.kubestellar.io/missions/install-submariner).
- The mission wraps the current `subctl` workflow (deploy-broker, join, verify, cross-cluster connectivity test) in a guided UI.
- Discussed and approved by maintainers @dfarrell07 and @tpantelis in [submariner-io/submariner#3907](https://github.com/submariner-io/submariner/issues/3907).

## Test plan
- [ ] `_index.en.md` renders correctly in Hugo build
- [ ] Link resolves: https://console.kubestellar.io/missions/install-submariner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new quickstart guide for KubeStellar Console Submariner installation with an integrated guided UI workflow for deployment and cross-cluster connectivity configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->