### PR TITLE
Add 0.24.0 release notes for several PRs

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -17,6 +17,7 @@ weight = 40
 * Fixed potential scenarios where multiple gateway pods could have their active status label set incorrectly.
 * Fixed `subctl upgrade` image pull failures caused by improper handling of version strings with "v" prefix.
 * Fixed a race condition where the VXLAN tunnel interface could be incorrectly deleted when switching cable drivers.
+* Fixed IPv6 protocol conflicts in nftables rules for dual-stack and IPv6-only environments.
 
 ## v0.23.1 (March 12, 2026)
 

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -16,6 +16,7 @@ weight = 40
 * Service Discovery now implements the CoreDNS Readiness interface so that a readiness probe does not observe it as ready prematurely.
 * Fixed potential scenarios where multiple gateway pods could have their active status label set incorrectly.
 * Fixed `subctl upgrade` image pull failures caused by improper handling of version strings with "v" prefix.
+* Fixed a race condition where the VXLAN tunnel interface could be incorrectly deleted when switching cable drivers.
 
 ## v0.23.1 (March 12, 2026)
 

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -15,6 +15,7 @@ weight = 40
 * Fixed an issue with OVN-Kubernetes where non-Submariner routes and policies were incorrectly deleted during reconciliation.
 * Service Discovery now implements the CoreDNS Readiness interface so that a readiness probe does not observe it as ready prematurely.
 * Fixed potential scenarios where multiple gateway pods could have their active status label set incorrectly.
+* Fixed `subctl upgrade` image pull failures caused by improper handling of version strings with "v" prefix.
 
 ## v0.23.1 (March 12, 2026)
 


### PR DESCRIPTION
See commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v0.24.0 release notes to document three additional bug fixes: `subctl upgrade` version string handling, VXLAN cable driver switching improvements, and IPv6 nftables rule generation fixes for dual-stack environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->