### PR TITLE
Merge release notes for 0.24.0

### DIFF
--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -5,7 +5,7 @@ weight = 40
 +++
 <!-- markdownlint-disable no-duplicate-heading -->
 
-## v0.24.0
+## v0.24.0 (May 12, 2026)
 
 ### New features
 

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -17,6 +17,7 @@ weight = 40
 * Fixed potential scenarios where multiple gateway pods could have their active status label set incorrectly.
 * Fixed `subctl upgrade` image pull failures caused by improper handling of version strings with "v" prefix.
 * Fixed a race condition where the VXLAN tunnel interface could be incorrectly deleted when switching cable drivers.
+* Fixed IPv6 protocol conflicts in nftables rules for dual-stack and IPv6-only environments.
 
 ## v0.23.1 (March 12, 2026)
 

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -5,6 +5,12 @@ weight = 40
 +++
 <!-- markdownlint-disable no-duplicate-heading -->
 
+## v0.24.0
+
+### New features
+
+### Other changes
+
 ## v0.23.1 (March 12, 2026)
 
 * AWS cloud prepare now adds Kubernetes cluster tags to security groups to comply with LoadBalancer security group restrictions.

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -11,6 +11,7 @@ weight = 40
 
 ### Other changes
 
+* Azure cloud prepare now supports Marketplace-based images for gateway MachineSet creation on ARO-style clusters.
 * Fixed potential scenarios where multiple gateway pods could have their active status label set incorrectly.
 
 ## v0.23.1 (March 12, 2026)

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -11,6 +11,8 @@ weight = 40
 
 ### Other changes
 
+* Fixed potential scenarios where multiple gateway pods could have their active status label set incorrectly.
+
 ## v0.23.1 (March 12, 2026)
 
 * AWS cloud prepare now adds Kubernetes cluster tags to security groups to comply with LoadBalancer security group restrictions.

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -16,6 +16,7 @@ weight = 40
 * Service Discovery now implements the CoreDNS Readiness interface so that a readiness probe does not observe it as ready prematurely.
 * Fixed potential scenarios where multiple gateway pods could have their active status label set incorrectly.
 * Fixed `subctl upgrade` image pull failures caused by improper handling of version strings with "v" prefix.
+* Fixed a race condition where the VXLAN tunnel interface could be incorrectly deleted when switching cable drivers.
 
 ## v0.23.1 (March 12, 2026)
 

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -15,6 +15,7 @@ weight = 40
 * Fixed an issue with OVN-Kubernetes where non-Submariner routes and policies were incorrectly deleted during reconciliation.
 * Service Discovery now implements the CoreDNS Readiness interface so that a readiness probe does not observe it as ready prematurely.
 * Fixed potential scenarios where multiple gateway pods could have their active status label set incorrectly.
+* Fixed `subctl upgrade` image pull failures caused by improper handling of version strings with "v" prefix.
 
 ## v0.23.1 (March 12, 2026)
 

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -13,6 +13,7 @@ weight = 40
 
 * Azure cloud prepare now supports Marketplace-based images for gateway MachineSet creation on ARO-style clusters.
 * Fixed an issue with OVN-Kubernetes where non-Submariner routes and policies were incorrectly deleted during reconciliation.
+* Service Discovery now implements the CoreDNS Readiness interface so that a readiness probe does not observe it as ready prematurely.
 * Fixed potential scenarios where multiple gateway pods could have their active status label set incorrectly.
 
 ## v0.23.1 (March 12, 2026)

--- a/src/content/community/releases/_index.en.md
+++ b/src/content/community/releases/_index.en.md
@@ -12,6 +12,7 @@ weight = 40
 ### Other changes
 
 * Azure cloud prepare now supports Marketplace-based images for gateway MachineSet creation on ARO-style clusters.
+* Fixed an issue with OVN-Kubernetes where non-Submariner routes and policies were incorrectly deleted during reconciliation.
 * Fixed potential scenarios where multiple gateway pods could have their active status label set incorrectly.
 
 ## v0.23.1 (March 12, 2026)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v0.24.0 (May 12, 2026) with improvements including Azure Marketplace image support, OVN-Kubernetes reconciliation deletion fix, CoreDNS readiness interface implementation for Service Discovery, gateway pod active label corrections, subctl upgrade image pull version-string handling, VXLAN tunnel deletion race condition fix, and nftables IPv6 dual-stack/IPv6 conflict resolution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/submariner-io/submariner-website/pull/1333)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->