### PR TITLE
Remove calendar

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -62,9 +62,3 @@ name = "<i class='fab fa-fw fa-twitter'></i> Twitter"
 identifier = "twitter"
 url = "https://twitter.com/submarinerio"
 weight = 60
-
-[[Languages.en.menu.shortcuts]]
-name = "<i class='fas fa-fw fa-calendar'></i> Google Calendar"
-identifier = "gcal"
-url = "https://calendar.google.com/calendar?cid=NHFuZGVoOGY0bzZ1ajlvZnBsczh1NWNlZ2tAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ"
-weight = 70

--- a/src/content/community/getting-help/_index.en.md
+++ b/src/content/community/getting-help/_index.en.md
@@ -22,8 +22,6 @@ can [request an invite to Kubernetes' Slack instance](https://slack.k8s.io/).
 
 Submariner's meetings are open to everyone. All meetings are documented on [Submariner's Community
 Calendar](https://calendar.google.com/calendar/r?cid=NHFuZGVoOGY0bzZ1ajlvZnBsczh1NWNlZ2tAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
-The bi-weekly [Submariner Dev, Users & Community Meeting](https://docs.google.com/document/d/1IhTMQMWkDj_V9ZfHI9szy3xZ3dZb0yMEHhP2y_ivzRU/edit#heading=h.ky2m2ggopkp1)
-(Mondays at 3:00pm CET) is a good place to start.
 
 #### Mailing List
 


### PR DESCRIPTION
Remove links to google calendare

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the Google Calendar shortcut from the main navigation menu.
  * Removed the Community Calendar subsection from the Getting Help documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/submariner-io/submariner-website/pull/1334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->