### PR TITLE
Switch to depends-on/depends-on-action for PR dependencies

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -2,25 +2,15 @@
 name: PR Dependencies
 
 on:
-  issues:
-    types:
-      - opened
-      - edited
-      - closed
-      - reopened
-      - synchronize
   pull_request_target:
     types:
       - opened
       - edited
-      - closed
       - reopened
       - synchronize
 
 permissions:
-  issues: write
   pull-requests: write
-  statuses: write
 
 jobs:
   check:
@@ -28,15 +18,7 @@ jobs:
     if: github.repository_owner == 'submariner-io'
     runs-on: ubuntu-latest
     steps:
-      - uses: z0al/dependent-issues@950226e7ca8fc43dc209a7febf67c655af3bdb43
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: depends-on/depends-on-action@e7915c70317af4efc4e6c4a4eb1e9260e215270c  # v0.16.0
         with:
-          # The label to use to mark dependent issues
-          label: dependent
-
-          # Enable checking for dependencies in issues.
-          check_issues: on
-
-          # A comma-separated list of keywords to mark dependency.
-          keywords: depends on, Depends on
+          token: ${{ secrets.GITHUB_TOKEN }}
+          check-unmerged-pr: true


### PR DESCRIPTION
This PR switches from the unmaintained z0al/dependent-issues action to the actively maintained depends-on/depends-on-action for checking PR dependencies.